### PR TITLE
#46 feat: 메인페이지 공연 목록 API 연동 및 데이터 표시

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,25 +1,27 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import fetchPerformances from "../../api/performance.ts";
 import MainPageCarousel from "../../components/swiper/MainPageCarousel.tsx";
 import Header from "../../components/layout/Header.tsx";
 import Footer from "../../components/layout/Footer.tsx";
 import Category from "../../components/layout/Category.tsx";
 
-// 메인 화면에 보여질 mock 데이터
-const popularPerformances = Array.from({ length: 10 }, (_, index) => ({
-	id: index + 1,
-	name: "햄릿",
-	stadiumName: "서울예술의전당",
-	startDate: "2025-08-01",
-	endDate: "2025-08-31",
-}));
-
 export default function MainPage() {
+	const [page, setPage] = useState(1);
+
+	const { data, isLoading, isError, error } = useQuery({
+		queryKey: ["popularPerformances", page],
+		queryFn: () => fetchPerformances(page, 10),
+		placeholderData: (prev) => prev,
+	});
+
+	const performances = data?.data.performances ?? [];
+	const pagination = data?.pagination;
+
 	return (
 		<>
-			{/* 상단 부분 */}
 			<Header />
 			<Category />
-
-			{/* 중간 부분 */}
 			<main className="bg-[#FBFBFB]">
 				<div className="max-w-7xl mx-auto py-16 px-4 md:px-6">
 					<MainPageCarousel />
@@ -27,11 +29,30 @@ export default function MainPage() {
 						인기 공연
 					</h2>
 
-					{/* 반응형 구현부분 */}
+					{isLoading && (
+						<p className="text-center py-10">
+							공연 목록을 불러오는 중입니다...
+						</p>
+					)}
+
+					{isError && (
+						<div className="text-center py-10">
+							<p className="text-red-500 font-semibold">오류가 발생했습니다.</p>
+							<p className="text-gray-600 mt-2">
+								{error instanceof Error ? error.message : "알 수 없는 에러"}
+							</p>
+						</div>
+					)}
+
+					{/* 공연 목록 */}
 					<div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5 md:gap-6">
-						{popularPerformances.map((performance) => (
+						{performances.map((performance) => (
 							<div key={performance.id}>
-								<div className="h-64 bg-gray-200 rounded-2xl mb-3 sm:h-72 lg:h-80" />
+								<img
+									src={performance.imageUrl}
+									alt={`${performance.name} 포스터`}
+									className="w-full h-64 sm:h-72 lg:h-80 rounded-2xl mb-3 object-cover bg-gray-200"
+								/>
 								<div className="flex flex-col gap-y-2">
 									<p className="font-bold text-base text-gray-900 break-all md:text-lg">
 										{performance.name}
@@ -46,10 +67,29 @@ export default function MainPage() {
 							</div>
 						))}
 					</div>
+
+					{/* 페이지네이션 */}
+					<div className="flex justify-center items-center gap-x-4 mt-12">
+						<button
+							type="button"
+							onClick={() => setPage((p) => p - 1)}
+							disabled={page === 1}
+							className="px-4 py-2 bg-gray-200 rounded-md disabled:opacity-50 disabled:cursor-not-allowed">
+							이전
+						</button>
+						<span>
+							{page} / {pagination?.totalPages ?? 1}
+						</span>
+						<button
+							type="button"
+							onClick={() => setPage((p) => p + 1)}
+							disabled={!pagination?.hasNext}
+							className="px-4 py-2 bg-gray-200 rounded-md disabled:opacity-50 disabled:cursor-not-allowed">
+							다음
+						</button>
+					</div>
 				</div>
 			</main>
-
-			{/* 하단 부분 */}
 			<Footer />
 		</>
 	);

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -5,6 +5,7 @@ import MainPageCarousel from "../../components/swiper/MainPageCarousel.tsx";
 import Header from "../../components/layout/Header.tsx";
 import Footer from "../../components/layout/Footer.tsx";
 import Category from "../../components/layout/Category.tsx";
+import { PerformanceListItem } from "../../types/ApiDataTypes.ts";
 
 export default function MainPage() {
 	const [page, setPage] = useState(1);
@@ -12,10 +13,10 @@ export default function MainPage() {
 	const { data, isLoading, isError, error } = useQuery({
 		queryKey: ["popularPerformances", page],
 		queryFn: () => fetchPerformances(page, 10),
-		placeholderData: (prev) => prev,
+		keepPreviousData: true,
 	});
 
-	const performances = data?.data.performances ?? [];
+	const performances: PerformanceListItem[] = data?.data.performances ?? [];
 	const pagination = data?.pagination;
 
 	return (


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 메인페이지에 공연 API 연동하였습니다.
- 메인페이지 하단에 공연 목록을 불러오는 페이지 네이션 적용하였습니다.

## 📄 설계 문서 (Design Document)


## ✅ 테스트 계획 (Test Plan)


## 📝 변경 사항 요약 (Summary)

- MainPage.tsx api 연동 및 페이지 네이션 구현

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #46 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
