### PR TITLE
#63 bug: .env 환경 변수 로드 & API 호출 해결

### DIFF
--- a/src/api/ReviewLikes.ts
+++ b/src/api/ReviewLikes.ts
@@ -1,10 +1,9 @@
 import { authedJSON } from "../lib/apiClient.ts";
-import getEnvVar from "../utils/env.ts";
 
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchReviewLikes = async (id: string, like: boolean) => {
-	return authedJSON(`${VITE_BACKEND_SRT_API}/api/v1/reviews/${id}/likes`, {
+	return authedJSON(`${apiUrl}/api/v1/reviews/${id}/likes`, {
 		method: "POST",
 		headers: { "Content-Type": "Application/json" },
 		body: JSON.stringify({ like }),

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,11 +2,11 @@
 import type { User } from "../recoil/auth.ts";
 import { authedJSON, publicJSON } from "../lib/apiClient.ts";
 import { LoginResponse } from "../types/ApiDataTypes.ts";
-import getEnvVar from "../utils/env.ts";
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const loginWithKakao = async (authCode: string): Promise<LoginResponse> => {
-	return publicJSON(`${VITE_BACKEND_SRT_API}/api/v1/auth/kakao/login`, {
+	return publicJSON(`${apiUrl}/api/v1/auth/kakao/login`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({
@@ -17,7 +17,7 @@ const loginWithKakao = async (authCode: string): Promise<LoginResponse> => {
 };
 
 const fetchMyInfo = async (): Promise<User> => {
-	return authedJSON(`${VITE_BACKEND_SRT_API}/api/v1/me`, {
+	return authedJSON(`${apiUrl}/api/v1/me`, {
 		method: "GET",
 		headers: { "Content-Type": "application/json" },
 	});

--- a/src/api/confirmPayment.ts
+++ b/src/api/confirmPayment.ts
@@ -1,7 +1,7 @@
 import { authedJSON } from "../lib/apiClient.ts";
 import { ConfirmPaymentResponse } from "../types/ApiDataTypes.ts";
-import getEnvVar from "../utils/env.ts";
-const VITE_BACKEND_PAYMENT_API = getEnvVar("VITE_BACKEND_PAYMENT_API");
+
+const apiUrl = process.env.BACKEND_PAYMENT_API;
 
 const fetchConfirmPayment = async (
 	reservationId: string,
@@ -9,7 +9,7 @@ const fetchConfirmPayment = async (
 	paymentKey: string
 ) => {
 	return authedJSON<ConfirmPaymentResponse>(
-		`${VITE_BACKEND_PAYMENT_API}/api/v1/payments/confirm`,
+		`${apiUrl}/api/v1/payments/confirm`,
 		{
 			method: "POST",
 			headers: {

--- a/src/api/performance.ts
+++ b/src/api/performance.ts
@@ -1,18 +1,16 @@
 import { publicJSON } from "../lib/apiClient.ts";
 import { PerformanceData } from "../types/ApiDataTypes.ts";
-import getEnvVar from "../utils/env.ts";
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchPerformances = async (
 	page: number,
-	size = 10
+	size = 32
 ): Promise<PerformanceData> => {
-	const url = `${VITE_BACKEND_SRT_API}/api/v1/performances?${new URLSearchParams(
-		{
-			page: String(page),
-			size: String(size),
-		}
-	)}`;
+	const url = `${apiUrl}/api/v1/performances?${new URLSearchParams({
+		page: String(page),
+		size: String(size),
+	})}`;
 
 	return publicJSON(url, {
 		method: "GET",

--- a/src/api/performanceDetail.ts
+++ b/src/api/performanceDetail.ts
@@ -1,12 +1,12 @@
 import { PerformanceDetailData } from "../types/ApiDataTypes.ts";
 import { authedJSON } from "../lib/apiClient.ts";
-import getEnvVar from "../utils/env.ts";
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchPerformanceDetail = async (
 	id: string
 ): Promise<PerformanceDetailData> => {
-	return authedJSON(`${VITE_BACKEND_SRT_API}/api/v1/performances/${id}`, {
+	return authedJSON(`${apiUrl}/api/v1/performances/${id}`, {
 		method: "GET",
 		headers: { "Content-Type": "application/json" },
 	});

--- a/src/api/performanceReview.ts
+++ b/src/api/performanceReview.ts
@@ -1,31 +1,25 @@
 import { authedJSON } from "../lib/apiClient.ts";
 import { reviewData } from "../types/ApiDataTypes.ts";
-import getEnvVar from "../utils/env.ts";
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchGetReview = async (id: string) => {
-	return authedJSON<reviewData>(
-		`${VITE_BACKEND_SRT_API}/api/v1/performances/${id}/reviews`,
-		{
-			method: "GET",
-			headers: { "Content-Type": "application/json" },
-		}
-	);
+	return authedJSON<reviewData>(`${apiUrl}/api/v1/performances/${id}/reviews`, {
+		method: "GET",
+		headers: { "Content-Type": "application/json" },
+	});
 };
 
 const fetchPostReview = async (id: string, content: string, star: number) => {
-	return authedJSON(
-		`${VITE_BACKEND_SRT_API}/api/v1/performances/${id}/reviews`,
-		{
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ content, star }),
-		}
-	);
+	return authedJSON(`${apiUrl}/api/v1/performances/${id}/reviews`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ content, star }),
+	});
 };
 
 const fetchPatchReview = async (reviewId: string, content: string) => {
-	return authedJSON(`${VITE_BACKEND_SRT_API}/api/v1/reviews/${reviewId}`, {
+	return authedJSON(`${apiUrl}/api/v1/reviews/${reviewId}`, {
 		method: "PATCH",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ content }),
@@ -33,7 +27,7 @@ const fetchPatchReview = async (reviewId: string, content: string) => {
 };
 
 const fetchDeleteReview = async (reviewId: string) => {
-	return authedJSON(`${VITE_BACKEND_SRT_API}/api/v1/reviews/${reviewId}`, {
+	return authedJSON(`${apiUrl}/api/v1/reviews/${reviewId}`, {
 		method: "DELETE",
 		headers: { "Content-Type": "application/json" },
 	});

--- a/src/api/reservation.ts
+++ b/src/api/reservation.ts
@@ -3,14 +3,13 @@ import {
 	ReservationResponse,
 } from "../types/ApiDataTypes.ts";
 import { authedJSON } from "../lib/apiClient.ts";
-import getEnvVar from "../utils/env.ts";
 
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchPostReservation = async (
 	body: ReservationRequest
 ): Promise<ReservationResponse> => {
-	return authedJSON(`${VITE_BACKEND_SRT_API}/api/v1/reservation`, {
+	return authedJSON(`${apiUrl}/api/v1/reservation`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",

--- a/src/api/seats.ts
+++ b/src/api/seats.ts
@@ -1,18 +1,15 @@
 import { authedJSON } from "../lib/apiClient.ts";
 import { selectSeatsData } from "../types/ApiDataTypes.ts";
-import getEnvVar from "../utils/env.ts";
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchSeats = async (id: string): Promise<selectSeatsData> => {
-	return authedJSON(
-		`${VITE_BACKEND_SRT_API}/api/v1/stadiums/${id}/seat-definitions`,
-		{
-			method: "GET",
-			headers: {
-				"Content-Type": "application/json",
-			},
-		}
-	);
+	return authedJSON(`${apiUrl}/api/v1/stadiums/${id}/seat-definitions`, {
+		method: "GET",
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
 };
 
 export default fetchSeats;

--- a/src/api/seatsStates.ts
+++ b/src/api/seatsStates.ts
@@ -1,13 +1,12 @@
 import { seatStateData } from "../types/ApiDataTypes.ts";
 import { authedJSON } from "../lib/apiClient.ts";
-import getEnvVar from "../utils/env.ts";
 
 type Raw = { code: string; data: { seats: seatStateData[] } };
-const VITE_BACKEND_SRT_API = getEnvVar("VITE_BACKEND_SRT_API");
+const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchSeatsStates = async (id: string) => {
 	const json = await authedJSON<Raw>(
-		`${VITE_BACKEND_SRT_API}/api/v1/schedules/${id}/seat-states`,
+		`${apiUrl}/api/v1/schedules/${id}/seat-states`,
 		{
 			method: "GET",
 			headers: {

--- a/src/components/__mocks__/performanceData.ts
+++ b/src/components/__mocks__/performanceData.ts
@@ -4,7 +4,7 @@ import perfImage from "../../assets/images/Performance1.gif";
 const performanceData: PerformanceData = {
 	code: "SUCCESS",
 	data: {
-		performances: Array.from({ length: 40 }).map((_, index) => ({
+		performances: Array.from({ length: 100 }).map((_, index) => ({
 			id: `mock-${index + 1}`,
 			name: `공연 이름-${index + 1}`,
 			imageUrl: perfImage,
@@ -17,9 +17,9 @@ const performanceData: PerformanceData = {
 		})),
 	},
 	pagination: {
-		page: 1,
-		size: 10,
-		totalItems: 40,
+		page: 0,
+		size: 32,
+		totalItems: 100,
 		totalPages: 4,
 		hasNext: true,
 		hasPrevious: false,

--- a/src/components/common/AppInitializer.tsx
+++ b/src/components/common/AppInitializer.tsx
@@ -12,7 +12,7 @@ export default function AppInitializer({
 
 	useEffect(() => {
 		if (window.Kakao && !window.Kakao.isInitialized()) {
-			window.Kakao.init(import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY);
+			window.Kakao.init(process.env.KAKAO_JAVASCRIPT_KEY);
 			setKakaoSdkReady(true);
 		} else if (window.Kakao?.isInitialized()) {
 			setKakaoSdkReady(true);

--- a/src/components/payment/PaymentCheckout.tsx
+++ b/src/components/payment/PaymentCheckout.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import Debouncing from "../../utils/Debouncing.ts";
 import useElapsedTime from "../../hooks/useElapsedTime.ts";
 
-const { VITE_TOSS_CLIENT_KEY } = import.meta.env;
+const apiUrl = process.env.TOSS_CLIENT_KEY ?? "";
+
 const customerKey = `user-id`; // OAuth로 받은 user.id 값을 사용
 
 export default function TossPaymentCheckout({
@@ -35,7 +36,7 @@ export default function TossPaymentCheckout({
 
 		async function fetchPayment() {
 			try {
-				const tossPayments = await loadTossPayments(VITE_TOSS_CLIENT_KEY);
+				const tossPayments = await loadTossPayments(apiUrl);
 
 				// 회원 결제
 				const paymentInfo = tossPayments.payment({

--- a/src/hooks/usePerformances.ts
+++ b/src/hooks/usePerformances.ts
@@ -3,10 +3,10 @@ import fetchPerformances from "../api/performance.ts";
 import { PerformanceData } from "../types/ApiDataTypes.ts";
 import { ApiError } from "../lib/apiClient.ts";
 
-export default function usePerformances(size = 10) {
+export default function usePerformances(size = 32) {
 	return useInfiniteQuery<PerformanceData, ApiError>({
 		queryKey: ["performances", size],
-		queryFn: ({ pageParam = 1 }) => fetchPerformances(pageParam, size),
+		queryFn: ({ pageParam = 0 }) => fetchPerformances(pageParam, size),
 		getNextPageParam: (lastPage) =>
 			lastPage.pagination.hasNext ? lastPage.pagination.page + 1 : undefined,
 	});

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -13,18 +13,18 @@ import { ConfirmPaymentRequest } from "../types/ApiDataTypes.ts";
 
 const handlers = [
 	// performance - 공연 관련 API
-	http.get(`/api/v1/performances`, ({ request }) => {
+	http.get(`http://localhost:18081/api/v1/performances`, ({ request }) => {
 		const url = new URL(request.url);
-		const page = Number(url.searchParams.get("page") ?? 1);
-		const size = Number(url.searchParams.get("size") ?? 10);
+		const page = Number(url.searchParams.get("page") ?? 0);
+		const size = Number(url.searchParams.get("size") ?? 32);
 
-		const startIndex = (page - 1) * size;
-		const endIndex = startIndex + size;
+		const totalItems = performanceData.data.performances.length;
+		const totalPages = Math.ceil(totalItems / size);
 
-		const slicedList = performanceData.data.performances.slice(
-			startIndex,
-			endIndex
-		);
+		const start = page * size;
+		const end = Math.min(start + size, totalItems);
+
+		const slicedList = performanceData.data.performances.slice(start, end);
 
 		return HttpResponse.json({
 			code: "SUCCESS",
@@ -34,15 +34,15 @@ const handlers = [
 			pagination: {
 				page,
 				size,
-				totalItems: performanceData.data.performances.length,
-				totalPages: Math.ceil(performanceData.data.performances.length / size),
-				hasNext: endIndex < performanceData.data.performances.length,
-				hasPrevious: page > 1,
+				totalItems,
+				totalPages,
+				hasNext: page < totalPages - 1,
+				hasPrevious: page > 0,
 			},
 		});
 	}),
 
-	http.get(`/api/v1/performances/:id`, ({ params }) => {
+	http.get(`http://localhost:18081/api/v1/performances/:id`, ({ params }) => {
 		const { id } = params;
 
 		if (id === performanceDetailData.data.id) {
@@ -52,21 +52,24 @@ const handlers = [
 	}),
 
 	// Review - 공연 리뷰 관련 API
-	http.get(`/api/v1/performances/:id/reviews`, () => {
+	http.get(`http://localhost:18081/api/v1/performances/:id/reviews`, () => {
 		return HttpResponse.json(performanceReview);
 	}),
 
-	http.post("/api/v1/performances/:id/reviews", async () => {
-		return HttpResponse.json({
-			code: "SUCCESS",
-			data: {
-				id: "b8c9d3fa-2f1a-4a5d-9e2a-812f7a91cdef",
-				createdAt: "2025-07-11T12:45:00",
-			},
-		});
-	}),
+	http.post(
+		"http://localhost:18081/api/v1/performances/:id/reviews",
+		async () => {
+			return HttpResponse.json({
+				code: "SUCCESS",
+				data: {
+					id: "b8c9d3fa-2f1a-4a5d-9e2a-812f7a91cdef",
+					createdAt: "2025-07-11T12:45:00",
+				},
+			});
+		}
+	),
 
-	http.patch("/api/v1/reviews/:id", async () => {
+	http.patch("http://localhost:18081/api/v1/reviews/:id", async () => {
 		return HttpResponse.json({
 			code: "SUCCESS",
 			data: {
@@ -76,25 +79,28 @@ const handlers = [
 		});
 	}),
 
-	http.delete("/api/v1/reviews/:id", () => {
+	http.delete("http://localhost:18081/api/v1/reviews/:id", () => {
 		return HttpResponse.json({ success: true });
 	}),
 
-	http.post("/api/v1/reviews/:id/likes", async ({ request }) => {
-		const { like } = (await request.json()) as { like: boolean };
-		return HttpResponse.json({
-			code: "SUCCESS",
-			data: { likeStatus: like },
-		});
-	}),
+	http.post(
+		"http://localhost:18081/api/v1/reviews/:id/likes",
+		async ({ request }) => {
+			const { like } = (await request.json()) as { like: boolean };
+			return HttpResponse.json({
+				code: "SUCCESS",
+				data: { likeStatus: like },
+			});
+		}
+	),
 
 	// 로그인 요청 핸들러입니다.
-	http.post("/api/v1/auth/kakao/login", () => {
+	http.post("http://localhost:18081/api/v1/auth/kakao/login", () => {
 		return HttpResponse.json(mockLoginResponse);
 	}),
 
 	// 사용자 정보 조회 요청 핸들러입니다.
-	http.get("/api/v1/me", ({ request }) => {
+	http.get("http://localhost:18081/api/v1/me", ({ request }) => {
 		const authorizationHeader = request.headers.get("Authorization");
 		if (!authorizationHeader) {
 			return new HttpResponse(null, {
@@ -105,40 +111,46 @@ const handlers = [
 		return HttpResponse.json(mockUserData);
 	}),
 
-	http.get("/api/v1/stadiums/:id/seat-definitions", () => {
-		return HttpResponse.json(selectSeatsAllData);
-	}),
+	http.get(
+		"http://localhost:18081/api/v1/stadiums/:id/seat-definitions",
+		() => {
+			return HttpResponse.json(selectSeatsAllData);
+		}
+	),
 
-	http.get("/api/v1/schedules/:id/seat-states", () => {
+	http.get("http://localhost:18081/api/v1/schedules/:id/seat-states", () => {
 		return HttpResponse.json(seatsStateData);
 	}),
 
-	http.post("/api/v1/reservation", () => {
+	http.post("http://localhost:18081/api/v1/reservation", () => {
 		return HttpResponse.json(reservationData);
 	}),
 
 	// 결제 승인 요청 핸들러입니다.
-	http.post("/api/v1/payments/confirm", async ({ request }) => {
-		const { orderId, amount, paymentKey } =
-			(await request.json()) as ConfirmPaymentRequest;
+	http.post(
+		"http://localhost:18082/api/v1/payments/confirm",
+		async ({ request }) => {
+			const { orderId, amount, paymentKey } =
+				(await request.json()) as ConfirmPaymentRequest;
 
-		// 간단한 유효성 검사
-		if (!orderId || !amount || !paymentKey) {
-			return HttpResponse.json(
-				{ code: "INVALID_REQUEST", message: "Invalid request parameters" },
-				{ status: 400 }
-			);
+			// 간단한 유효성 검사
+			if (!orderId || !amount || !paymentKey) {
+				return HttpResponse.json(
+					{ code: "INVALID_REQUEST", message: "Invalid request parameters" },
+					{ status: 400 }
+				);
+			}
+
+			// 성공적인 결제 승인 응답 예시
+			return HttpResponse.json({
+				code: "SUCCESS",
+				data: {
+					reservationId: "resJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+					totalAmount: 10000,
+				},
+				message: null,
+			});
 		}
-
-		// 성공적인 결제 승인 응답 예시
-		return HttpResponse.json({
-			code: "SUCCESS",
-			data: {
-				reservationId: "resJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
-				totalAmount: 10000,
-			},
-			message: null,
-		});
-	}),
+	),
 ];
 export default handlers;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -4,7 +4,7 @@ export default function LoginPage() {
 	const handleKakaoLogin = () => {
 		if (window.Kakao) {
 			window.Kakao.Auth.authorize({
-				redirectUri: import.meta.env.VITE_KAKAO_REDIRECT_URI,
+				redirectUri: process.env.KAKAO_REDIRECT_KEY,
 			});
 		}
 	};

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -14,7 +14,7 @@ export default function MainPage() {
 
 	const { data, isLoading, isError, error } = useQuery({
 		queryKey: ["popularPerformances", page],
-		queryFn: () => fetchPerformances(page, 10),
+		queryFn: () => fetchPerformances(page - 1, 10),
 		keepPreviousData: true,
 	});
 
@@ -91,7 +91,7 @@ export default function MainPage() {
 					<div className="flex justify-center items-center gap-x-4 mt-12">
 						<button
 							type="button"
-							onClick={() => setPage((p) => p - 1)}
+							onClick={() => setPage((p) => Math.max(p - 1, 1))}
 							disabled={page === 1}
 							className="px-4 py-2 bg-gray-200 rounded-md disabled:opacity-50 disabled:cursor-not-allowed">
 							이전

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,5 +1,0 @@
-export default function getEnvVar(
-	key: keyof ImportMetaEnv
-): string | undefined {
-	return process.env[key];
-}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,12 +3,3 @@ interface Window {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Kakao: any;
 }
-
-interface ImportMetaEnv {
-	readonly VITE_BACKEND_SRT_API: string;
-	readonly VITE_BACKEND_PAYMENT_API: string;
-}
-
-interface ImportMeta {
-	readonly env: ImportMetaEnv;
-}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,39 +1,28 @@
 {
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "module": "ES2020",
-    "skipLibCheck": true,
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": false,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "allowSyntheticDefaultImports": true,
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": false,
-    "types": [
-      "jest",
-      "@testing-library/jest-dom",
-      "node",
-      "vite/client"
-    ]
-  },
-  "include": [
-    "src"
-  ]
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"module": "ES2020",
+		"skipLibCheck": true,
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": false,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"jsx": "react-jsx",
+		"allowSyntheticDefaultImports": true,
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": false,
+		"types": ["jest", "@testing-library/jest-dom", "node", "vite/client"]
+	},
+	"include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,26 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
-export default defineConfig({
-	plugins: [react(), tailwindcss()],
-	server: {
-		port: 15173,
-	},
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, process.cwd());
+	const processEnv = Object.keys(env)
+		.filter((key) => key.startsWith("VITE_"))
+		.reduce(
+			(acc, key) => {
+				const newKey = key.replace(/^VITE_/, "");
+				acc[`process.env.${newKey}`] = JSON.stringify(env[key]);
+				return acc;
+			},
+			{} as Record<string, string>
+		);
+
+	return {
+		plugins: [react(), tailwindcss()],
+		server: {
+			port: 15173,
+		},
+		define: processEnv,
+	};
 });


### PR DESCRIPTION
## 🛠️ 설명 (Description)

기존에 배포된 코드는, 백엔드 API를 제대로 호출하지 못했습니다.
또한, 공연 목록 조회 시, `page`를 `0`부터, `size`를 `32`개씩 조회해야 하는데 이와 동일하게 진행하지 않아, 
데이터를 정상적으로 불러오지 못했습니다.
이러한 환경 변수 로드 & API 호출 문제들을 해결합니다.

## 📄 설계 문서 (Design Document)
## ✅ 테스트 계획 (Test Plan)
## 📝 변경 사항 요약 (Summary)

- 기존에 사용한 `getEnvVar` 컴포넌트는, `import.meta.env` 호출 방식 실패에 따라, 변형하여 제작하였습니다. 하지만 해당 방식 역시, 제대로 진행되지 않아, `process.env` 호출 방식을 착안하여 재수정하였습니다.
- 공연 목록 조회 시, API 규격에 맞도록 `page` & `size` 크기를 재수정하였습니다.
- 
## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #63 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI 파이프라인이 성공했습니다.
## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
## ➕ 추가 정보 (Additional Information)
