### PR TITLE
fix: 경로 중복을 방지하기 위해 scp 명령의 DIST_DIR에 슬래시 추가

### DIFF
--- a/.github/workflows/production-cd.yml
+++ b/.github/workflows/production-cd.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           scp -r -o StrictHostKeyChecking=no \
               -J ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }}:${{ secrets.BASTION_PORT }} \
-              ${{env.DIST_DIR}} \
+              ${{env.DIST_DIR}}/ \
               ${{ secrets.DAISY04_USER }}@${{ secrets.DAISY04_HOST }}:${{ env.APP_DIR }}/
 
       - name: 애플리케이션 서버에 변경 사항 적용


### PR DESCRIPTION
빌드 파일 dist 중첩 문제 해결
- 정상
/dist/...
- 에러
/dist/dist/..