### PR TITLE
#82 refactor(domain.performance) 인기 공연 조회 로직 개선

### DIFF
--- a/src/api/popularPerformance.ts
+++ b/src/api/popularPerformance.ts
@@ -13,7 +13,6 @@ const fetchPopularPerformances = async (): Promise<PopularPerformanceData> => {
 		method: "GET",
 		credentials: "include",
 		headers: {
-			"Content-Type": "application/json",
 			accept: "application/json",
 		},
 	});

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -13,7 +13,7 @@ export default function MainPage() {
 	const { data, isLoading, isError, error } = useQuery({
 		queryKey: ["popularPerformances"],
 		queryFn: () => fetchPopularPerformances(),
-		keepPreviousData: true,
+		staleTime: 1000 * 60,
 	});
 
 	const handleClick = (id: string, adultOnly: boolean) => {

--- a/src/types/ApiDataTypes.ts
+++ b/src/types/ApiDataTypes.ts
@@ -32,7 +32,7 @@ export interface PerformancePagination {
 	hasNext: boolean;
 	hasPrevious: boolean;
 }
-
+/** 공연 목록을 조회하여 응답으로 받는 데이터 타입입니다. */
 export interface PerformanceData {
 	code: string;
 	data: {
@@ -41,6 +41,7 @@ export interface PerformanceData {
 	pagination: PerformancePagination;
 }
 
+/** 인기 공연 목록을 조회하기 위한 데이터 타입입니다. */
 export interface PopularPerformanceData {
 	code: string;
 	data: {


### PR DESCRIPTION
## 🛠️ 설명 (Description)

기존에는 인기 공연 조회 방식이 모든 공연 정보를 불러와 페이지네이션으로 처리했습니다.
이는 잘못된 조회 방식이므로, 새로운 API 호출(조회수 기준 상위 10개)로 인기 공연을 불러오도록 하였습니다.

## 📄 설계 문서 (Design Document)

## ✅ 테스트 계획 (Test Plan)

- API 응답 데이터 상태 확인

## 📝 변경 사항 요약 (Summary)

- 인기 공연 조회 로직 페이지네이션 방식 제거
- 불필요한 페이징 처리 코드 제거
- 새로운 API 호출(조회수 순 상위 10개 조회)

## 🔗 관련 이슈 (Related Issues)

- Closes #82 
- Related #None

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
