### PR TITLE
#121 refactor(architecture): Global Layout, Route Guard, Query Key Factory, 타입 분리 아키텍처 리팩토링

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -1,7 +1,7 @@
 // 로그인, 정보 조회를 위한 API 호출 함수 정의
-import type { User } from "../store/authStore";
-import { authedJSON, publicJSON } from "../lib/apiClient.ts";
-import { LoginResponse } from "../types/ApiDataTypes.ts";
+import type { User } from "../../store/authStore";
+import { authedJSON, publicJSON } from "../../lib/apiClient.ts";
+import { LoginResponse } from "../../types/ApiDataTypes.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/payment/confirmPayment.ts
+++ b/src/api/payment/confirmPayment.ts
@@ -1,5 +1,5 @@
-import { authedJSON } from "../lib/apiClient.ts";
-import { ConfirmPaymentResponse } from "../types/ApiDataTypes.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
+import { ConfirmPaymentResponse } from "../../types/ApiDataTypes.ts";
 
 const apiUrl = process.env.BACKEND_PAYMENT_API;
 

--- a/src/api/performance/ReviewLikes.ts
+++ b/src/api/performance/ReviewLikes.ts
@@ -1,4 +1,4 @@
-import { authedJSON } from "../lib/apiClient.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/performance/performance.ts
+++ b/src/api/performance/performance.ts
@@ -1,5 +1,5 @@
-import { publicJSON } from "../lib/apiClient.ts";
-import { PerformanceData } from "../types/ApiDataTypes.ts";
+import { publicJSON } from "../../lib/apiClient.ts";
+import { PerformanceData } from "../../types/ApiDataTypes.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/performance/performanceDetail.ts
+++ b/src/api/performance/performanceDetail.ts
@@ -1,5 +1,5 @@
-import { PerformanceDetailData } from "../types/ApiDataTypes.ts";
-import { authedJSON } from "../lib/apiClient.ts";
+import { PerformanceDetailData } from "../../types/ApiDataTypes.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/performance/performanceReview.ts
+++ b/src/api/performance/performanceReview.ts
@@ -1,5 +1,5 @@
-import { authedJSON } from "../lib/apiClient.ts";
-import { reviewData } from "../types/ApiDataTypes.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
+import { reviewData } from "../../types/ApiDataTypes.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/performance/popularPerformance.ts
+++ b/src/api/performance/popularPerformance.ts
@@ -1,5 +1,5 @@
-import { PopularPerformanceData } from "../types/ApiDataTypes.ts";
-import { publicJSON } from "../lib/apiClient.ts";
+import { PopularPerformanceData } from "../../types/ApiDataTypes.ts";
+import { publicJSON } from "../../lib/apiClient.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -1,0 +1,31 @@
+// Query Key Factory, 모든 TanStack Query의 queryKey를 중앙 관리
+
+export const performanceKeys = {
+	all: ["performances"] as const,
+	lists: () => [...performanceKeys.all, "list"] as const,
+	list: (size: number) => [...performanceKeys.lists(), size] as const,
+	popular: () => [...performanceKeys.all, "popular"] as const,
+	details: () => [...performanceKeys.all, "detail"] as const,
+	detail: (id: string) => [...performanceKeys.details(), id] as const,
+} as const;
+
+export const reviewKeys = {
+	all: ["reviews"] as const,
+	lists: () => [...reviewKeys.all, "list"] as const,
+	list: (performanceId: string) =>
+		[...reviewKeys.lists(), performanceId] as const,
+} as const;
+
+export const seatKeys = {
+	all: ["seats"] as const,
+	definitions: (stadiumId: string) =>
+		[...seatKeys.all, "definitions", stadiumId] as const,
+	states: (scheduleId: string) =>
+		[...seatKeys.all, "states", scheduleId] as const,
+} as const;
+
+export const paymentKeys = {
+	all: ["payments"] as const,
+	confirm: (reservationId: string) =>
+		[...paymentKeys.all, "confirm", reservationId] as const,
+} as const;

--- a/src/api/reservation/reservation.ts
+++ b/src/api/reservation/reservation.ts
@@ -1,8 +1,8 @@
 import {
 	ReservationRequest,
 	ReservationResponse,
-} from "../types/ApiDataTypes.ts";
-import { authedJSON } from "../lib/apiClient.ts";
+} from "../../types/ApiDataTypes.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/reservation/seats.ts
+++ b/src/api/reservation/seats.ts
@@ -1,5 +1,5 @@
-import { authedJSON } from "../lib/apiClient.ts";
-import { selectSeatsData } from "../types/ApiDataTypes.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
+import { selectSeatsData } from "../../types/ApiDataTypes.ts";
 
 const apiUrl = process.env.BACKEND_SRT_API;
 

--- a/src/api/reservation/seatsStates.ts
+++ b/src/api/reservation/seatsStates.ts
@@ -1,5 +1,5 @@
-import { seatStateData } from "../types/ApiDataTypes.ts";
-import { authedJSON } from "../lib/apiClient.ts";
+import { seatStateData } from "../../types/ApiDataTypes.ts";
+import { authedJSON } from "../../lib/apiClient.ts";
 
 type Raw = { code: string; data: { seats: seatStateData[] } };
 

--- a/src/components/__tests__/reservation/SendSeatsButton.test.tsx
+++ b/src/components/__tests__/reservation/SendSeatsButton.test.tsx
@@ -4,7 +4,7 @@ import sendSeatsData from "../../__mocks__/sendSeatsData.ts";
 import SendSeatsButton from "../../reservation/SendSeatsButton.tsx";
 import useElapsedTime from "../../../hooks/useElapsedTime.ts";
 import "@testing-library/jest-dom";
-import fetchPostReservation from "../../../api/reservation.ts";
+import fetchPostReservation from "../../../api/reservation/reservation.ts";
 
 // useNavigate mocking
 const navigateMock = jest.fn();

--- a/src/components/__tests__/reservation/SendSeatsButton.test.tsx
+++ b/src/components/__tests__/reservation/SendSeatsButton.test.tsx
@@ -20,7 +20,7 @@ jest.mock("../../../hooks/useElapsedTime.ts", () => ({
 
 const mockedUseElapsedTime = useElapsedTime as jest.Mock;
 
-jest.mock("../../../api/reservation.ts", () => ({
+jest.mock("../../../api/reservation/reservation.ts", () => ({
 	__esModule: true,
 	default: jest.fn().mockReturnValue({ id: "reservation-1" }),
 }));

--- a/src/components/layout/GlobalLayout.tsx
+++ b/src/components/layout/GlobalLayout.tsx
@@ -1,0 +1,17 @@
+// 전역 레이아웃: Header + 페이지 콘텐츠(Outlet) + Footer를 자동 적용
+// React Router의 Layout Route 패턴을 활용하여, 하위 Route가 <Outlet /> 위치에 렌더링됨
+import { Outlet } from "react-router-dom";
+import Header from "./Header.tsx";
+import Footer from "./Footer.tsx";
+
+export default function GlobalLayout() {
+	return (
+		<div className="min-h-screen flex flex-col bg-[#FBFBFB]">
+			<Header />
+			<main className="flex-1">
+				<Outlet />
+			</main>
+			<Footer />
+		</div>
+	);
+}

--- a/src/components/performance/detail/review/ReviewItem.tsx
+++ b/src/components/performance/detail/review/ReviewItem.tsx
@@ -2,7 +2,7 @@ import { FaRegStar, FaStar, FaStarHalfAlt } from "react-icons/fa";
 import { FormEvent, useState } from "react";
 import { reviewList } from "../../../../types/ApiDataTypes.ts";
 import ReviewLikeButton from "./ReviewLikeButton.tsx";
-import fetchReviewLikes from "../../../../api/ReviewLikes.ts";
+import fetchReviewLikes from "../../../../api/performance/ReviewLikes.ts";
 import ReviewRating from "./ReviewRating.tsx";
 import DeleteConfirmModal from "../../../common/DeleteConfirmModal.tsx";
 

--- a/src/components/reservation/SendSeatsButton.tsx
+++ b/src/components/reservation/SendSeatsButton.tsx
@@ -4,7 +4,7 @@ import {
 	ReservationRequest,
 	ReservationResponse,
 } from "../../types/ApiDataTypes.ts";
-import fetchPostReservation from "../../api/reservation.ts";
+import fetchPostReservation from "../../api/reservation/reservation.ts";
 
 interface SendSeatsButtonProps {
 	performanceId: string;

--- a/src/components/reservation/loading/WaitingRoom.tsx
+++ b/src/components/reservation/loading/WaitingRoom.tsx
@@ -1,8 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
-import fetchSeats from "../../../api/seats.ts";
+import fetchSeats from "../../../api/reservation/seats.ts";
 import Countdown from "./Countdown.tsx";
-import fetchSeatsStates from "../../../api/seatsStates.ts";
+import fetchSeatsStates from "../../../api/reservation/seatsStates.ts";
+import { seatKeys } from "../../../api/queryKeys.ts";
 
 interface WaitingRoomProps {
 	stadiumId: string;
@@ -27,13 +28,13 @@ export default function WaitingRoom({
 
 			await Promise.all([
 				qc.prefetchQuery({
-					queryKey: ["seats", scheduleId],
+					queryKey: seatKeys.definitions(stadiumId),
 					queryFn: () => fetchSeats(stadiumId),
 					staleTime: 15 * 60 * 1000,
 					cacheTime: 30 * 60 * 1000,
 				}),
 				qc.prefetchQuery({
-					queryKey: ["seatStatus", scheduleId],
+					queryKey: seatKeys.states(scheduleId),
 					queryFn: () => fetchSeatsStates(scheduleId),
 					staleTime: 60 * 1000,
 					cacheTime: 30 * 60 * 1000,

--- a/src/hooks/usePerformances.ts
+++ b/src/hooks/usePerformances.ts
@@ -1,11 +1,12 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import fetchPerformances from "../api/performance.ts";
+import fetchPerformances from "../api/performance/performance.ts";
 import { PerformanceData } from "../types/ApiDataTypes.ts";
 import { ApiError } from "../lib/apiClient.ts";
+import { performanceKeys } from "../api/queryKeys.ts";
 
 export default function usePerformances(size = 32) {
 	return useInfiniteQuery<PerformanceData, ApiError>({
-		queryKey: ["performances", size],
+		queryKey: performanceKeys.list(size),
 		queryFn: ({ pageParam = 0 }) => fetchPerformances(pageParam, size),
 		getNextPageParam: (lastPage) => {
 			const { pagination } = lastPage;

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -5,14 +5,15 @@ import {
 	fetchGetReview,
 	fetchPatchReview,
 	fetchPostReview,
-} from "../api/performanceReview.ts";
+} from "../api/performance/performanceReview.ts";
 import { ApiError } from "../lib/apiClient.ts";
+import { reviewKeys } from "../api/queryKeys.ts";
 
 export default function useReviews(id: string) {
 	const queryClient = useQueryClient();
 
 	const { data, status, error } = useQuery<reviewData, ApiError>({
-		queryKey: ["performanceReviews", id],
+		queryKey: reviewKeys.list(id),
 		queryFn: () => fetchGetReview(id!),
 		enabled: !!id,
 		useErrorBoundary: false,
@@ -25,7 +26,7 @@ export default function useReviews(id: string) {
 		onSubmit: async (content: string, star: number) => {
 			try {
 				await fetchPostReview(id, content, star);
-				queryClient.invalidateQueries({ queryKey: ["performanceReviews", id] });
+				queryClient.invalidateQueries({ queryKey: reviewKeys.list(id) });
 			} catch (err) {
 				if (err && typeof err === "object" && "status" in err) {
 					const apiError = err as { status: number };
@@ -44,7 +45,7 @@ export default function useReviews(id: string) {
 		onEdit: async (reviewId: string, content: string, star: number) => {
 			try {
 				await fetchPatchReview(reviewId, content, star);
-				queryClient.invalidateQueries({ queryKey: ["performanceReviews", id] });
+				queryClient.invalidateQueries({ queryKey: reviewKeys.list(id) });
 			} catch {
 				throw new Error("리뷰 수정 중 오류가 발생했습니다.");
 			}
@@ -52,13 +53,13 @@ export default function useReviews(id: string) {
 		onDelete: async (reviewId: string) => {
 			try {
 				await fetchDeleteReview(reviewId);
-				queryClient.invalidateQueries({ queryKey: ["performanceReviews", id] });
+				queryClient.invalidateQueries({ queryKey: reviewKeys.list(id) });
 			} catch {
 				throw new Error("리뷰 삭제 중 오류가 발생했습니다.");
 			}
 		},
 		onLikeToggle: () => {
-			queryClient.invalidateQueries({ queryKey: ["performanceReviews", id] });
+			queryClient.invalidateQueries({ queryKey: reviewKeys.list(id) });
 		},
 	};
 }

--- a/src/pages/about/AboutPage.tsx
+++ b/src/pages/about/AboutPage.tsx
@@ -1,7 +1,5 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
-import Header from "../../components/layout/Header.tsx";
-import Footer from "../../components/layout/Footer.tsx";
 
 const teamMembers = [
 	{
@@ -67,107 +65,99 @@ export default function AboutPage() {
 		}
 	}, [location]);
 	return (
-		<div className="min-h-screen bg-[#FBFBFB] flex flex-col">
-			<Header />
-
-			<main className="flex-1">
-				<section className="relative bg-blue-400 py-20 md:py-32 overflow-hidden mb-16 md:mb-24">
-					<div className="absolute inset-0 opacity-20">
-						<div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1515100398104-f7221da41f1b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjaW5lbWElMjB0aGVhdGVyJTIwaW50ZXJpb3J8ZW58MXx8fHwxNzY1Mjg1NDMwfDA&ixlib=rb-4.1.0&q=80&w=1080')] bg-cover bg-center" />
+		<>
+			<section className="relative bg-blue-400 py-20 md:py-32 overflow-hidden mb-16 md:mb-24">
+				<div className="absolute inset-0 opacity-20">
+					<div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1515100398104-f7221da41f1b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjaW5lbWElMjB0aGVhdGVyJTIwaW50ZXJpb3J8ZW58MXx8fHwxNzY1Mjg1NDMwfDA&ixlib=rb-4.1.0&q=80&w=1080')] bg-cover bg-center" />
+				</div>
+				<div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+					<div className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full border border-white/20 mb-6">
+						<span className="text-white text-sm">About NextFrame</span>
 					</div>
-					<div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-						<div className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full border border-white/20 mb-6">
-							<span className="text-white text-sm">About NextFrame</span>
-						</div>
-						<h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-							차세대 공연 플랫폼을
-							<br />
-							만들어갑니다
-						</h1>
-						<p className="text-white/80 text-lg md:text-xl max-w-3xl mx-auto">
-							시네마틱 UX와 인터랙티브 기술을 결합해
-							<br className="hidden md:block" />
-							공연 예매의 새로운 기준을 제시합니다
-						</p>
-					</div>
-				</section>
+					<h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+						차세대 공연 플랫폼을
+						<br />
+						만들어갑니다
+					</h1>
+					<p className="text-white/80 text-lg md:text-xl max-w-3xl mx-auto">
+						시네마틱 UX와 인터랙티브 기술을 결합해
+						<br className="hidden md:block" />
+						공연 예매의 새로운 기준을 제시합니다
+					</p>
+				</div>
+			</section>
 
-				<section id="team" className="py-16 md:py-24 mb-16 md:mb-24">
-					<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-						<div className="text-center mb-16">
-							<h2 className="text-3xl md:text-4xl font-bold text-blue-950 mb-4">
-								개발 팀
-							</h2>
-							<p className="text-gray-600 text-lg">
-								NextFrame을 만드는 개발자들
-							</p>
-						</div>
-						<div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-							{teamMembers.map((member) => (
-								<div
-									key={member.github}
-									className="group bg-white rounded-2xl overflow-hidden border border-gray-200 hover:border-[#2E2356]/30 hover:shadow-xl transition-all duration-300 hover:-translate-y-2">
-									<div className="relative overflow-hidden">
-										<div className="absolute inset-0 bg-gradient-to-t from-[#2E2356] to-transparent opacity-0 group-hover:opacity-70 transition-opacity duration-300 z-10" />
-										<img
-											src={`https://github.com/${member.github}.png`}
-											alt={member.name}
-											className="w-full h-64 object-cover group-hover:scale-110 transition-transform duration-300"
-										/>
-									</div>
-									<div className="p-6">
-										<div className="inline-block px-4 py-2 bg-purple-100 rounded-full mb-3">
-											<span className="text-[#2E2356] text-sm font-medium">
-												{member.role}
-											</span>
-										</div>
-										<h3 className="text-2xl font-bold text-blue-950 mb-3">
-											{member.name}
-										</h3>
-										<a
-											href={`https://github.com/${member.github}`}
-											target="_blank"
-											rel="noopener noreferrer"
-											className="text-base text-gray-500 hover:text-[#2E2356] transition-colors mb-4 inline-block">
-											@{member.github}
-										</a>
-										<ul className="space-y-3">
-											{member.responsibilities.map((task) => (
-												<li
-													key={task}
-													className="text-gray-600 text-base flex items-start">
-													<span className="text-[#2E2356] mr-2 mt-1">•</span>
-													<span>{task}</span>
-												</li>
-											))}
-										</ul>
-									</div>
-								</div>
-							))}
-						</div>
-					</div>
-				</section>
-
-				<section className="py-16 md:py-24 bg-blue-400">
-					<div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-						<h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
-							프로젝트에 참여하세요 !
+			<section id="team" className="py-16 md:py-24 mb-16 md:mb-24">
+				<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+					<div className="text-center mb-16">
+						<h2 className="text-3xl md:text-4xl font-bold text-blue-950 mb-4">
+							개발 팀
 						</h2>
-						<p className="text-white/80 text-lg mb-8">
-							함께 더 나은 공연 플랫폼을 만들어갈 수 있습니다
-						</p>
-						<a
-							href="https://github.com/next-frame-lab"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="px-8 py-3 bg-white text-blue-950 font-medium rounded-lg hover:bg-white/90 transition-all inline-block">
-							기여하기
-						</a>
+						<p className="text-gray-600 text-lg">NextFrame을 만드는 개발자들</p>
 					</div>
-				</section>
-			</main>
+					<div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+						{teamMembers.map((member) => (
+							<div
+								key={member.github}
+								className="group bg-white rounded-2xl overflow-hidden border border-gray-200 hover:border-[#2E2356]/30 hover:shadow-xl transition-all duration-300 hover:-translate-y-2">
+								<div className="relative overflow-hidden">
+									<div className="absolute inset-0 bg-gradient-to-t from-[#2E2356] to-transparent opacity-0 group-hover:opacity-70 transition-opacity duration-300 z-10" />
+									<img
+										src={`https://github.com/${member.github}.png`}
+										alt={member.name}
+										className="w-full h-64 object-cover group-hover:scale-110 transition-transform duration-300"
+									/>
+								</div>
+								<div className="p-6">
+									<div className="inline-block px-4 py-2 bg-purple-100 rounded-full mb-3">
+										<span className="text-[#2E2356] text-sm font-medium">
+											{member.role}
+										</span>
+									</div>
+									<h3 className="text-2xl font-bold text-blue-950 mb-3">
+										{member.name}
+									</h3>
+									<a
+										href={`https://github.com/${member.github}`}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-base text-gray-500 hover:text-[#2E2356] transition-colors mb-4 inline-block">
+										@{member.github}
+									</a>
+									<ul className="space-y-3">
+										{member.responsibilities.map((task) => (
+											<li
+												key={task}
+												className="text-gray-600 text-base flex items-start">
+												<span className="text-[#2E2356] mr-2 mt-1">•</span>
+												<span>{task}</span>
+											</li>
+										))}
+									</ul>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			</section>
 
-			<Footer />
-		</div>
+			<section className="py-16 md:py-24 bg-blue-400">
+				<div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+					<h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+						프로젝트에 참여하세요 !
+					</h2>
+					<p className="text-white/80 text-lg mb-8">
+						함께 더 나은 공연 플랫폼을 만들어갈 수 있습니다
+					</p>
+					<a
+						href="https://github.com/next-frame-lab"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="px-8 py-3 bg-white text-blue-950 font-medium rounded-lg hover:bg-white/90 transition-all inline-block">
+						기여하기
+					</a>
+				</div>
+			</section>
+		</>
 	);
 }

--- a/src/pages/about/AboutPage.tsx
+++ b/src/pages/about/AboutPage.tsx
@@ -1,6 +1,9 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
+const IMAGE_URL =
+	"https://images.unsplash.com/photo-1515100398104-f7221da41f1b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjaW5lbWElMjB0aGVhdGVyJTIwaW50ZXJpb3J8ZW58MXx8fHwxNzY1Mjg1NDMwfDA&ixlib=rb-4.1.0&q=80&w=1080";
+
 const teamMembers = [
 	{
 		name: "김민서",
@@ -68,7 +71,10 @@ export default function AboutPage() {
 		<>
 			<section className="relative bg-blue-400 py-20 md:py-32 overflow-hidden mb-16 md:mb-24">
 				<div className="absolute inset-0 opacity-20">
-					<div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1515100398104-f7221da41f1b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjaW5lbWElMjB0aGVhdGVyJTIwaW50ZXJpb3J8ZW58MXx8fHwxNzY1Mjg1NDMwfDA&ixlib=rb-4.1.0&q=80&w=1080')] bg-cover bg-center" />
+					<div
+						className="absolute inset-0 bg-cover bg-center"
+						style={{ backgroundImage: `url(${IMAGE_URL})` }}
+					/>
 				</div>
 				<div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
 					<div className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full border border-white/20 mb-6">

--- a/src/pages/auth/KakaoRedirectPage.tsx
+++ b/src/pages/auth/KakaoRedirectPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import authApi from "../../api/auth.ts";
+import authApi from "../../api/auth/auth.ts";
 import { useAuthActions } from "../../store/authStore.ts";
 import getUserIdFromToken from "../../utils/auth.ts";
 

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,5 +1,5 @@
-import { useNavigate } from "react-router-dom";
-import Header from "../../components/layout/Header.tsx";
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const apiUrl =
 	process.env.MODE === "development"
@@ -12,7 +12,16 @@ const buttonBaseClass =
 
 export default function LoginPage() {
 	const navigate = useNavigate();
+	const location = useLocation();
 
+	// PrivateRoute에서 리다이렉트된 경우, 원래 가려던 경로를 sessionStorage에 저장
+	// KakaoRedirectPage에서 로그인 완료 후 이 경로로 복귀
+	useEffect(() => {
+		const from = (location.state as { from?: string })?.from;
+		if (from) {
+			sessionStorage.setItem("redirectTo", from);
+		}
+	}, [location.state]);
 	const handleKakaoLogin = () => {
 		if (isMockMode) {
 			navigate("/auth/kakao/callback?code=mockCode");
@@ -22,62 +31,59 @@ export default function LoginPage() {
 	};
 
 	return (
-		<div className="min-h-screen bg-[#FBFBFB] flex flex-col">
-			<Header />
-			<main className="flex flex-1 items-center justify-center p-4">
-				<div className="w-full max-w-md text-center space-y-8">
-					<div className="space-y-3">
-						<h1 className="text-3xl md:text-4xl font-bold text-blue-950">
-							로그인
-						</h1>
-						<p className="text-gray-500">소셜 계정으로 간편하게 로그인하세요</p>
-					</div>
-					<div className="flex flex-col items-center gap-3 px-4">
-						<button
-							type="button"
-							onClick={handleKakaoLogin}
-							className={`${buttonBaseClass} bg-[#FEE500] hover:bg-[#FDD800]`}>
-							<img
-								src="/icons/login/kakao_login.svg"
-								alt="Kakao"
-								width="18"
-								height="18"
-							/>
-							<span className="text-[#191919] font-medium text-sm">
-								카카오 로그인
-							</span>
-						</button>
-						<button
-							type="button"
-							onClick={() => alert("네이버 로그인 기능 준비중입니다.")}
-							className={`${buttonBaseClass} bg-[#03C75A] hover:bg-[#02b351]`}>
-							<img
-								src="/icons/login/naver_login.svg"
-								alt="Naver"
-								width="16"
-								height="16"
-							/>
-							<span className="text-white font-medium text-sm">
-								네이버 로그인
-							</span>
-						</button>
-						<button
-							type="button"
-							onClick={() => alert("Google 로그인 기능 준비중입니다.")}
-							className={`${buttonBaseClass} bg-white border border-gray-300 hover:bg-gray-50`}>
-							<img
-								src="/icons/login/google_login.svg"
-								alt="Google"
-								width="18"
-								height="18"
-							/>
-							<span className="text-gray-700 font-medium text-sm">
-								Google 로그인
-							</span>
-						</button>
-					</div>
+		<div className="flex items-center justify-center min-h-[calc(100vh-160px)] p-4">
+			<div className="w-full max-w-md text-center space-y-8">
+				<div className="space-y-3">
+					<h1 className="text-3xl md:text-4xl font-bold text-blue-950">
+						로그인
+					</h1>
+					<p className="text-gray-500">소셜 계정으로 간편하게 로그인하세요</p>
 				</div>
-			</main>
+				<div className="flex flex-col items-center gap-3 px-4">
+					<button
+						type="button"
+						onClick={handleKakaoLogin}
+						className={`${buttonBaseClass} bg-[#FEE500] hover:bg-[#FDD800]`}>
+						<img
+							src="/icons/login/kakao_login.svg"
+							alt="Kakao"
+							width="18"
+							height="18"
+						/>
+						<span className="text-[#191919] font-medium text-sm">
+							카카오 로그인
+						</span>
+					</button>
+					<button
+						type="button"
+						onClick={() => alert("네이버 로그인 기능 준비중입니다.")}
+						className={`${buttonBaseClass} bg-[#03C75A] hover:bg-[#02b351]`}>
+						<img
+							src="/icons/login/naver_login.svg"
+							alt="Naver"
+							width="16"
+							height="16"
+						/>
+						<span className="text-white font-medium text-sm">
+							네이버 로그인
+						</span>
+					</button>
+					<button
+						type="button"
+						onClick={() => alert("Google 로그인 기능 준비중입니다.")}
+						className={`${buttonBaseClass} bg-white border border-gray-300 hover:bg-gray-50`}>
+						<img
+							src="/icons/login/google_login.svg"
+							alt="Google"
+							width="18"
+							height="18"
+						/>
+						<span className="text-gray-700 font-medium text-sm">
+							Google 로그인
+						</span>
+					</button>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,17 +1,16 @@
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import HeroCarousel from "../../components/carousel/HeroCarousel.tsx";
-import Header from "../../components/layout/Header.tsx";
-import Footer from "../../components/layout/Footer.tsx";
 import Category from "../../components/layout/Category.tsx";
 import { PerformanceListItem } from "../../types/ApiDataTypes.ts";
-import fetchPopularPerformances from "../../api/popularPerformance.ts";
+import fetchPopularPerformances from "../../api/performance/popularPerformance.ts";
+import { performanceKeys } from "../../api/queryKeys.ts";
 
 export default function MainPage() {
 	const navigate = useNavigate();
 
 	const { data, isLoading, isError, error } = useQuery({
-		queryKey: ["popularPerformances"],
+		queryKey: performanceKeys.popular(),
 		queryFn: () => fetchPopularPerformances(),
 		staleTime: 1000 * 60,
 	});
@@ -24,8 +23,7 @@ export default function MainPage() {
 	const performances: PerformanceListItem[] = data?.data.performances ?? [];
 
 	return (
-		<main className="bg-[#FBFBFB]">
-			<Header />
+		<>
 			<HeroCarousel />
 			<Category />
 			<div className="max-w-7xl mx-auto mb-6 px-4 md:px-6">
@@ -141,7 +139,6 @@ export default function MainPage() {
 					))}
 				</div>
 			</div>
-			<Footer />
-		</main>
+		</>
 	);
 }

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -7,8 +7,6 @@ import {
 import { FilmIcon, HeartIcon, StarIcon } from "@heroicons/react/24/outline";
 import { Link } from "react-router-dom";
 import { useAuthState } from "../../store/authStore.ts";
-import Header from "../../components/layout/Header.tsx";
-import Footer from "../../components/layout/Footer.tsx";
 
 const KEYWORDS = [
 	{ id: "concert", label: "콘서트", path: "/performances?type=concert" },
@@ -55,125 +53,115 @@ export default function MyPage() {
 
 	if (!user) {
 		return (
-			<div className="min-h-screen bg-[#FBFBFB] flex flex-col">
-				<Header />
-				<main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-12">
-					<div className="bg-white rounded-xl shadow-sm border border-gray-200 p-12 text-center">
-						<p className="text-gray-600">
-							로그인 정보가 없습니다. 로그인 페이지로 이동해주세요.
-						</p>
-					</div>
-				</main>
-				<Footer />
+			<div className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-12">
+				<div className="bg-white rounded-xl shadow-sm border border-gray-200 p-12 text-center">
+					<p className="text-gray-600">
+						로그인 정보가 없습니다. 로그인 페이지로 이동해주세요.
+					</p>
+				</div>
 			</div>
 		);
 	}
 
 	return (
-		<div className="min-h-screen bg-[#FBFBFB] flex flex-col">
-			<Header />
+		<div className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-12">
+			{/* 프로필 */}
+			<div className="mb-16 mt-6 rounded-xl bg-white border border-gray-200 p-8 md:p-12 hover:shadow-lg transition-all max-w-5xl mx-auto">
+				<div className="flex flex-col md:flex-row items-center gap-8">
+					<img
+						src={user.imageUrl}
+						alt={`${user.name}의 프로필 이미지`}
+						className="w-32 h-32 rounded-full object-cover border-4 border-gray-100"
+					/>
 
-			<main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-12">
-				{/* 프로필 */}
-				<div className="mb-16 mt-6 rounded-xl bg-white border border-gray-200 p-8 md:p-12 hover:shadow-lg transition-all max-w-5xl mx-auto">
-					<div className="flex flex-col md:flex-row items-center gap-8">
-						<img
-							src={user.imageUrl}
-							alt={`${user.name}의 프로필 이미지`}
-							className="w-32 h-32 rounded-full object-cover border-4 border-gray-100"
-						/>
+					<div className="flex-1 text-center md:text-left">
+						<h1 className="text-3xl font-bold text-blue-950 mb-2">
+							{user.name}
+						</h1>
+						<p className="text-gray-500 mb-4">NextFrame 회원</p>
 
-						<div className="flex-1 text-center md:text-left">
-							<h1 className="text-3xl font-bold text-blue-950 mb-2">
-								{user.name}
-							</h1>
-							<p className="text-gray-500 mb-4">NextFrame 회원</p>
-
-							<div className="flex items-center gap-2 justify-center md:justify-start mb-3">
-								<TagIcon className="w-4 h-4 text-gray-400" />
-								<p className="text-sm text-gray-500 font-medium">
-									관심 공연 키워드
-								</p>
-							</div>
-
-							<div className="flex flex-wrap gap-2 justify-center md:justify-start">
-								{KEYWORDS.map((keyword) => (
-									<Link
-										key={keyword.id}
-										to={keyword.path}
-										className="px-4 py-2 bg-gradient-to-r from-purple-400 to-purple-500 text-white text-sm font-medium rounded-full border border-purple-400 hover:from-purple-500 hover:to-purple-600 transition-all">
-										{keyword.label}
-									</Link>
-								))}
-							</div>
-						</div>
-
-						<div className="hidden lg:flex">
-							<div className="px-6 py-4 bg-purple-50 rounded-xl border border-purple-200">
-								<div className="flex items-center gap-3">
-									<div className="w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center">
-										<TicketIcon className="w-5 h-5 text-purple-600" />
-									</div>
-									<div>
-										<p className="text-gray-500 text-xs">이번 달 예매</p>
-										<p className="text-blue-950 text-xl font-semibold">3건</p>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				{/* 개인 정보 */}
-				<div className="bg-white rounded-xl border border-gray-200 overflow-hidden max-w-5xl mx-auto mb-16">
-					<div className="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-gray-50 to-white">
-						<h3 className="text-lg font-semibold text-blue-950">개인 정보</h3>
-					</div>
-					<div className="p-6">
-						<div className="grid md:grid-cols-2 gap-6">
-							<div className="flex items-start gap-4">
-								<div className="w-12 h-12 bg-blue-50 rounded-xl flex items-center justify-center">
-									<EnvelopeIcon className="w-5 h-5 text-blue-600" />
-								</div>
-								<div>
-									<p className="text-blue-950/60 text-sm mb-1">이메일</p>
-									<p className="text-blue-950 font-medium">{user.email}</p>
-								</div>
-							</div>
-
-							<div className="flex items-start gap-4">
-								<div className="w-12 h-12 bg-pink-50 rounded-xl flex items-center justify-center">
-									<CalendarIcon className="w-5 h-5 text-pink-600" />
-								</div>
-								<div>
-									<p className="text-blue-950/60 text-sm mb-1">나이</p>
-									<p className="text-blue-950 font-medium">{user.age}세</p>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				{/* 통계 카드 */}
-				<div className="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
-					{STATS.map((stat) => (
-						<div
-							key={stat.label}
-							className={`bg-white rounded-xl p-6 border border-gray-200 ${stat.hoverBorder} hover:shadow-lg hover:-translate-y-1 transition-all`}>
-							<div
-								className={`w-12 h-12 ${stat.bgColor} rounded-xl flex items-center justify-center mb-4`}>
-								<stat.icon className={`w-7 h-7 ${stat.iconColor} stroke-2`} />
-							</div>
-							<p className="text-3xl font-bold text-blue-950 mb-1">
-								{stat.count}
+						<div className="flex items-center gap-2 justify-center md:justify-start mb-3">
+							<TagIcon className="w-4 h-4 text-gray-400" />
+							<p className="text-sm text-gray-500 font-medium">
+								관심 공연 키워드
 							</p>
-							<p className="text-gray-500 text-sm">{stat.label}</p>
 						</div>
-					))}
-				</div>
-			</main>
 
-			<Footer />
+						<div className="flex flex-wrap gap-2 justify-center md:justify-start">
+							{KEYWORDS.map((keyword) => (
+								<Link
+									key={keyword.id}
+									to={keyword.path}
+									className="px-4 py-2 bg-gradient-to-r from-purple-400 to-purple-500 text-white text-sm font-medium rounded-full border border-purple-400 hover:from-purple-500 hover:to-purple-600 transition-all">
+									{keyword.label}
+								</Link>
+							))}
+						</div>
+					</div>
+
+					<div className="hidden lg:flex">
+						<div className="px-6 py-4 bg-purple-50 rounded-xl border border-purple-200">
+							<div className="flex items-center gap-3">
+								<div className="w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center">
+									<TicketIcon className="w-5 h-5 text-purple-600" />
+								</div>
+								<div>
+									<p className="text-gray-500 text-xs">이번 달 예매</p>
+									<p className="text-blue-950 text-xl font-semibold">3건</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* 개인 정보 */}
+			<div className="bg-white rounded-xl border border-gray-200 overflow-hidden max-w-5xl mx-auto mb-16">
+				<div className="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-gray-50 to-white">
+					<h3 className="text-lg font-semibold text-blue-950">개인 정보</h3>
+				</div>
+				<div className="p-6">
+					<div className="grid md:grid-cols-2 gap-6">
+						<div className="flex items-start gap-4">
+							<div className="w-12 h-12 bg-blue-50 rounded-xl flex items-center justify-center">
+								<EnvelopeIcon className="w-5 h-5 text-blue-600" />
+							</div>
+							<div>
+								<p className="text-blue-950/60 text-sm mb-1">이메일</p>
+								<p className="text-blue-950 font-medium">{user.email}</p>
+							</div>
+						</div>
+
+						<div className="flex items-start gap-4">
+							<div className="w-12 h-12 bg-pink-50 rounded-xl flex items-center justify-center">
+								<CalendarIcon className="w-5 h-5 text-pink-600" />
+							</div>
+							<div>
+								<p className="text-blue-950/60 text-sm mb-1">나이</p>
+								<p className="text-blue-950 font-medium">{user.age}세</p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* 통계 카드 */}
+			<div className="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+				{STATS.map((stat) => (
+					<div
+						key={stat.label}
+						className={`bg-white rounded-xl p-6 border border-gray-200 ${stat.hoverBorder} hover:shadow-lg hover:-translate-y-1 transition-all`}>
+						<div
+							className={`w-12 h-12 ${stat.bgColor} rounded-xl flex items-center justify-center mb-4`}>
+							<stat.icon className={`w-7 h-7 ${stat.iconColor} stroke-2`} />
+						</div>
+						<p className="text-3xl font-bold text-blue-950 mb-1">
+							{stat.count}
+						</p>
+						<p className="text-gray-500 text-sm">{stat.label}</p>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/pages/payment/FailPage.tsx
+++ b/src/pages/payment/FailPage.tsx
@@ -1,6 +1,4 @@
 import { useNavigate } from "react-router-dom";
-import Header from "../../components/layout/Header.tsx";
-import Footer from "../../components/layout/Footer.tsx";
 
 export default function FailPage() {
 	const navigate = useNavigate();
@@ -10,95 +8,91 @@ export default function FailPage() {
 	};
 
 	return (
-		<div>
-			<Header />
-			<main className="min-h-screen bg-gradient-to-b from-gray-50 to-white flex items-center justify-center py-12 px-4">
-				<div className="max-w-2xl w-full">
-					<div className="bg-white rounded-3xl shadow-2xl p-8 md:p-12">
-						{/* 에러 아이콘 */}
-						<div className="flex justify-center mb-6">
-							<div className="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-								<svg
-									className="w-12 h-12 text-red-600"
-									fill="none"
-									stroke="currentColor"
-									viewBox="0 0 24 24">
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										strokeWidth={2}
-										d="M6 18L18 6M6 6l12 12"
-									/>
-								</svg>
-							</div>
-						</div>
-
-						{/* 제목 */}
-						<h1 className="text-center text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-							결제 실패
-						</h1>
-
-						{/* 설명 */}
-						<p className="text-center text-lg text-gray-600 mb-8">
-							결제가 정상적으로 처리되지 않았습니다.
-							<br />
-							다시 시도해주세요.
-						</p>
-
-						{/* 안내 박스 */}
-						<div className="bg-red-50 border border-red-200 rounded-xl p-6 mb-8">
-							<div className="flex items-start gap-3">
-								<svg
-									className="w-6 h-6 text-red-600 flex-shrink-0 mt-0.5"
-									fill="none"
-									stroke="currentColor"
-									viewBox="0 0 24 24">
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										strokeWidth={2}
-										d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-									/>
-								</svg>
-								<div className="flex-1">
-									<p className="text-sm font-semibold text-red-900 mb-2">
-										결제 실패 원인
-									</p>
-									<ul className="text-sm text-red-800 space-y-1 list-disc list-inside">
-										<li>카드 한도 초과</li>
-										<li>잘못된 카드 정보 입력</li>
-										<li>네트워크 오류</li>
-										<li>결제 시스템 일시 장애</li>
-									</ul>
-								</div>
-							</div>
-						</div>
-
-						{/* 버튼 그룹 */}
-						<div className="space-y-3">
-							<button
-								type="button"
-								onClick={handleClick}
-								className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-bold text-lg py-4 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2">
-								<svg
-									className="w-5 h-5"
-									fill="none"
-									stroke="currentColor"
-									viewBox="0 0 24 24">
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										strokeWidth={2}
-										d="M10 19l-7-7m0 0l7-7m-7 7h18"
-									/>
-								</svg>
-								<span>돌아가기</span>
-							</button>
+		<main className="min-h-screen bg-gradient-to-b from-gray-50 to-white flex items-center justify-center py-12 px-4">
+			<div className="max-w-2xl w-full">
+				<div className="bg-white rounded-3xl shadow-2xl p-8 md:p-12">
+					{/* 에러 아이콘 */}
+					<div className="flex justify-center mb-6">
+						<div className="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+							<svg
+								className="w-12 h-12 text-red-600"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M6 18L18 6M6 6l12 12"
+								/>
+							</svg>
 						</div>
 					</div>
+
+					{/* 제목 */}
+					<h1 className="text-center text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+						결제 실패
+					</h1>
+
+					{/* 설명 */}
+					<p className="text-center text-lg text-gray-600 mb-8">
+						결제가 정상적으로 처리되지 않았습니다.
+						<br />
+						다시 시도해주세요.
+					</p>
+
+					{/* 안내 박스 */}
+					<div className="bg-red-50 border border-red-200 rounded-xl p-6 mb-8">
+						<div className="flex items-start gap-3">
+							<svg
+								className="w-6 h-6 text-red-600 flex-shrink-0 mt-0.5"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+								/>
+							</svg>
+							<div className="flex-1">
+								<p className="text-sm font-semibold text-red-900 mb-2">
+									결제 실패 원인
+								</p>
+								<ul className="text-sm text-red-800 space-y-1 list-disc list-inside">
+									<li>카드 한도 초과</li>
+									<li>잘못된 카드 정보 입력</li>
+									<li>네트워크 오류</li>
+									<li>결제 시스템 일시 장애</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+
+					{/* 버튼 그룹 */}
+					<div className="space-y-3">
+						<button
+							type="button"
+							onClick={handleClick}
+							className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-bold text-lg py-4 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2">
+							<svg
+								className="w-5 h-5"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M10 19l-7-7m0 0l7-7m-7 7h18"
+								/>
+							</svg>
+							<span>돌아가기</span>
+						</button>
+					</div>
 				</div>
-			</main>
-			<Footer />
-		</div>
+			</div>
+		</main>
 	);
 }

--- a/src/pages/payment/FailPage.tsx
+++ b/src/pages/payment/FailPage.tsx
@@ -8,7 +8,7 @@ export default function FailPage() {
 	};
 
 	return (
-		<main className="min-h-screen bg-gradient-to-b from-gray-50 to-white flex items-center justify-center py-12 px-4">
+		<div className="min-h-screen bg-gradient-to-b from-gray-50 to-white flex items-center justify-center py-12 px-4">
 			<div className="max-w-2xl w-full">
 				<div className="bg-white rounded-3xl shadow-2xl p-8 md:p-12">
 					{/* 에러 아이콘 */}
@@ -93,6 +93,6 @@ export default function FailPage() {
 					</div>
 				</div>
 			</div>
-		</main>
+		</div>
 	);
 }

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -19,10 +19,6 @@ export default function PaymentPage() {
 		if (invalid) {
 			navigate(-1);
 		}
-		const token = localStorage.getItem("accessToken");
-		if (!token) {
-			navigate("/login");
-		}
 	}, [invalid, navigate]);
 
 	if (invalid) return null;

--- a/src/pages/payment/SuccessPage.tsx
+++ b/src/pages/payment/SuccessPage.tsx
@@ -64,7 +64,7 @@ export default function SuccessPage() {
 	}, [searchParams, navigate]);
 
 	return paymentData ? (
-		<main className="bg-[#FBFBFB]">
+		<div className="bg-[#FBFBFB]">
 			<div className="mx-auto flex max-w-2xl flex-col items-center gap-y-6">
 				<div className="max-w-7xl mx-auto py-40">
 					<h1 className="text-center text-5xl font-bold pb-28">결제 성공!</h1>
@@ -85,9 +85,9 @@ export default function SuccessPage() {
 					</div>
 				</div>
 			</div>
-		</main>
+		</div>
 	) : (
-		<main className="bg-[#FBFBFB]">
+		<div className="bg-[#FBFBFB]">
 			<div className="mx-auto flex max-w-2xl flex-col items-center gap-y-6">
 				<div className="max-w-7xl mx-auto py-40">
 					<h1 className="text-center text-5xl font-bold pb-28">
@@ -97,6 +97,6 @@ export default function SuccessPage() {
 					<h2 className="text-center text-xl pb-10">잠시만 기다려주세요.</h2>
 				</div>
 			</div>
-		</main>
+		</div>
 	);
 }

--- a/src/pages/payment/SuccessPage.tsx
+++ b/src/pages/payment/SuccessPage.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import Header from "../../components/layout/Header.tsx";
-import Footer from "../../components/layout/Footer.tsx";
-import fetchConfirmPayment from "../../api/confirmPayment.ts";
+import fetchConfirmPayment from "../../api/payment/confirmPayment.ts";
 
 type PaymentData = {
 	reservationId: string;
@@ -65,51 +63,40 @@ export default function SuccessPage() {
 		confirmPayment();
 	}, [searchParams, navigate]);
 
-	return (
-		<div>
-			<Header />
+	return paymentData ? (
+		<main className="bg-[#FBFBFB]">
+			<div className="mx-auto flex max-w-2xl flex-col items-center gap-y-6">
+				<div className="max-w-7xl mx-auto py-40">
+					<h1 className="text-center text-5xl font-bold pb-28">결제 성공!</h1>
 
-			{paymentData ? (
-				<main className="bg-[#FBFBFB]">
-					<div className="mx-auto flex max-w-2xl flex-col items-center gap-y-6">
-						<div className="max-w-7xl mx-auto py-40">
-							<h1 className="text-center text-5xl font-bold pb-28">
-								결제 성공!
-							</h1>
+					<h2 className="text-center text-xl pb-10">
+						결제 완료되었습니다! 마이 페이지나 이메일을 통해 QR코드를 확인할 수
+						있습니다.
+					</h2>
 
-							<h2 className="text-center text-xl pb-10">
-								결제 완료되었습니다! 마이 페이지나 이메일을 통해 QR코드를 확인할
-								수 있습니다.
-							</h2>
-
-							{/* 확인 버튼 */}
-							<div className="py-20">
-								<button
-									type="button"
-									onClick={() => navigate("/mypage")}
-									className="w-full rounded-lg bg-gray-200 py-3 text-lg font-bold text-shadow-black hover:bg-blue-200">
-									확인하기
-								</button>
-							</div>
-						</div>
+					{/* 확인 버튼 */}
+					<div className="py-20">
+						<button
+							type="button"
+							onClick={() => navigate("/mypage")}
+							className="w-full rounded-lg bg-gray-200 py-3 text-lg font-bold text-shadow-black hover:bg-blue-200">
+							확인하기
+						</button>
 					</div>
-				</main>
-			) : (
-				<main className="bg-[#FBFBFB]">
-					<div className="mx-auto flex max-w-2xl flex-col items-center gap-y-6">
-						<div className="max-w-7xl mx-auto py-40">
-							<h1 className="text-center text-5xl font-bold pb-28">
-								승인 요청 중...
-							</h1>
+				</div>
+			</div>
+		</main>
+	) : (
+		<main className="bg-[#FBFBFB]">
+			<div className="mx-auto flex max-w-2xl flex-col items-center gap-y-6">
+				<div className="max-w-7xl mx-auto py-40">
+					<h1 className="text-center text-5xl font-bold pb-28">
+						승인 요청 중...
+					</h1>
 
-							<h2 className="text-center text-xl pb-10">
-								잠시만 기다려주세요.
-							</h2>
-						</div>
-					</div>
-				</main>
-			)}
-			<Footer />
-		</div>
+					<h2 className="text-center text-xl pb-10">잠시만 기다려주세요.</h2>
+				</div>
+			</div>
+		</main>
 	);
 }

--- a/src/pages/performance/PerformanceDetailPage.tsx
+++ b/src/pages/performance/PerformanceDetailPage.tsx
@@ -1,13 +1,12 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-import Header from "../../components/layout/Header.tsx";
-import Footer from "../../components/layout/Footer.tsx";
-import fetchPerformanceDetail from "../../api/performanceDetail.ts";
+import fetchPerformanceDetail from "../../api/performance/performanceDetail.ts";
 import PerformanceInfo from "../../components/performance/detail/PerformanceInfo.tsx";
 import { PerformanceDetailData } from "../../types/ApiDataTypes.ts";
 import { ApiError } from "../../lib/apiClient.ts";
 import AdultVerificationModal from "../../components/common/AdultVerificationModal.tsx";
+import { performanceKeys } from "../../api/queryKeys.ts";
 
 export default function PerformanceDetailPage() {
 	const { id } = useParams();
@@ -34,7 +33,7 @@ export default function PerformanceDetailPage() {
 	);
 
 	const { data, status } = useQuery<PerformanceDetailData, ApiError>({
-		queryKey: ["performanceDetail", id],
+		queryKey: performanceKeys.detail(id as string),
 		queryFn: () => fetchPerformanceDetail(id as string),
 		enabled,
 		retry: 0,
@@ -67,20 +66,16 @@ export default function PerformanceDetailPage() {
 	const handleClose = () => navigate(-1);
 
 	return (
-		<div>
-			<Header />
-			<main className="bg-[#FBFBFB]">
-				{adult && !confirmed && (
-					<AdultVerificationModal
-						isOpen
-						onClose={handleClose}
-						onConfirm={handleConfirm}
-					/>
-				)}
-				{status === "loading" && <p>로딩 중</p>}
-				{data && confirmed && <PerformanceInfo performance={data} />}
-			</main>
-			<Footer />
-		</div>
+		<>
+			{adult && !confirmed && (
+				<AdultVerificationModal
+					isOpen
+					onClose={handleClose}
+					onConfirm={handleConfirm}
+				/>
+			)}
+			{status === "loading" && <p>로딩 중</p>}
+			{data && confirmed && <PerformanceInfo performance={data} />}
+		</>
 	);
 }

--- a/src/pages/performance/PerformancePage.tsx
+++ b/src/pages/performance/PerformancePage.tsx
@@ -1,5 +1,3 @@
-import Footer from "../../components/layout/Footer.tsx";
-import Header from "../../components/layout/Header.tsx";
 import usePerformances from "../../hooks/usePerformances.ts";
 import InfiniteScroll from "../../components/ui/InfiniteScroll.tsx";
 import { AppErrorCode, statusMessage } from "../../lib/apiClient.ts";
@@ -30,24 +28,20 @@ export default function PerformancePage() {
 		data?.pages.flatMap((page) => page.data.performances) ?? [];
 
 	return (
-		<div>
-			<main className="bg-[#FBFBFB]">
-				<Header />
-				<Category />
-				<div className="max-w-7xl mx-auto py-16 px-4 md:px-6">
-					<h1 className="text-3xl text-blue-950 mb-8">공연 목록</h1>
-					<InfiniteScroll
-						hasMore={!!hasNextPage}
-						onFetchNext={fetchNextPage}
-						delay={1000}>
-						<PerformanceCard performances={performances} />
-					</InfiniteScroll>
-					{isFetchingNextPage && (
-						<p className="text-center py-4">더 많은 공연을 불러오는 중...</p>
-					)}
-				</div>
-				<Footer />
-			</main>
-		</div>
+		<>
+			<Category />
+			<div className="max-w-7xl mx-auto py-16 px-4 md:px-6">
+				<h1 className="text-3xl text-blue-950 mb-8">공연 목록</h1>
+				<InfiniteScroll
+					hasMore={!!hasNextPage}
+					onFetchNext={fetchNextPage}
+					delay={1000}>
+					<PerformanceCard performances={performances} />
+				</InfiniteScroll>
+				{isFetchingNextPage && (
+					<p className="text-center py-4">더 많은 공연을 불러오는 중...</p>
+				)}
+			</div>
+		</>
 	);
 }

--- a/src/pages/reservation/SeatSelectPage.tsx
+++ b/src/pages/reservation/SeatSelectPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -9,27 +9,19 @@ import {
 } from "../../types/ApiDataTypes.ts";
 import useSeatReservation from "../../hooks/useSeatReservation.ts";
 import SeatSelector from "../../components/reservation/SeatSelector.tsx";
-import fetchSeats from "../../api/seats.ts";
+import fetchSeats from "../../api/reservation/seats.ts";
 import ReservationInfo from "../../components/reservation/ReservationInfo.tsx";
 import WaitingRoom from "../../components/reservation/loading/WaitingRoom.tsx";
 import CombineSeatsWithState from "../../utils/CombineSeatsWithState.ts";
 import calculateTotalPrice from "../../utils/CalculatePrice.ts";
 import SendSeatsButton from "../../components/reservation/SendSeatsButton.tsx";
-import fetchSeatsStates from "../../api/seatsStates.ts";
+import fetchSeatsStates from "../../api/reservation/seatsStates.ts";
 import { ApiError } from "../../lib/apiClient.ts";
+import { seatKeys } from "../../api/queryKeys.ts";
 
 export default function SeatSelectPage() {
 	const { selectedSeats, selectedSeatIds, toggleSeat, resetSelection } =
 		useSeatReservation();
-
-	const navigate = useNavigate();
-
-	useEffect(() => {
-		const token = localStorage.getItem("accessToken");
-		if (!token) {
-			navigate("/login");
-		}
-	}, [navigate]);
 
 	// 시간 조절
 	const [elapsedTime, setElapsedTime] = useState<number | null>(null);
@@ -72,7 +64,7 @@ export default function SeatSelectPage() {
 		selectSeatsData,
 		ApiError
 	>({
-		queryKey: ["selectSeats", stadiumId],
+		queryKey: seatKeys.definitions(stadiumId),
 		queryFn: async () => fetchSeats(stadiumId),
 		enabled: !!stadiumId,
 		staleTime: Infinity,
@@ -83,7 +75,7 @@ export default function SeatSelectPage() {
 		seatStateData[],
 		ApiError
 	>({
-		queryKey: ["seatsState", scheduleId],
+		queryKey: seatKeys.states(scheduleId),
 		queryFn: () => fetchSeatsStates(scheduleId),
 		enabled: !!scheduleId,
 		refetchOnWindowFocus: true,

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -4,6 +4,8 @@ import {
 	Route,
 	RouterProvider,
 } from "react-router-dom";
+import GlobalLayout from "../components/layout/GlobalLayout.tsx";
+import RouteGuard from "./RouteGuard.tsx";
 import MainPage from "../pages/main/MainPage.tsx";
 import LoginPage from "../pages/login/LoginPage.tsx";
 import PerformancePage from "../pages/performance/PerformancePage.tsx";
@@ -21,26 +23,41 @@ import ErrorBoundary from "../components/ui/ErrorBoundary.tsx";
 const router = createBrowserRouter(
 	createRoutesFromElements(
 		<Route errorElement={<ErrorBoundary />}>
-			<Route index element={<MainPage />} />
-			<Route path="login" element={<LoginPage />} />
-			<Route path="mypage" element={<MyPage />} />
-			<Route path="about" element={<AboutPage />} />
-			<Route path="auth">
-				<Route path="kakao/callback" element={<KakaoRedirectPage />} />
-			</Route>
-			<Route path="performances">
-				<Route index element={<PerformancePage />} />
-				<Route path=":id">
-					<Route index element={<PerformanceDetailPage />} />
-					<Route path="seats" element={<SeatSelectPage />} />
+			{/* GlobalLayout: Header + Footer 자동 적용 */}
+			<Route element={<GlobalLayout />}>
+				{/* 누구나 접근 가능한 페이지 */}
+				<Route index element={<MainPage />} />
+				<Route path="about" element={<AboutPage />} />
+				<Route path="performances">
+					<Route index element={<PerformancePage />} />
+					<Route path=":id" element={<PerformanceDetailPage />} />
 				</Route>
+
+				{/* 로그인 상태에서 접근 시 → / 리다이렉트 */}
+				<Route element={<RouteGuard type="public" />}>
+					<Route path="login" element={<LoginPage />} />
+				</Route>
+
+				{/* 비로그인 상태에서 접근 시 → /login 리다이렉트 */}
+				<Route element={<RouteGuard type="private" />}>
+					<Route path="mypage" element={<MyPage />} />
+					<Route path="payments">
+						<Route path="success" element={<SuccessPage />} />
+						<Route path="fail" element={<FailPage />} />
+					</Route>
+				</Route>
+
+				<Route path="*" element={<NotFoundPage />} />
 			</Route>
-			<Route path="payments">
-				<Route index element={<PaymentPage />} />
-				<Route path="success" element={<SuccessPage />} />
-				<Route path="fail" element={<FailPage />} />
+
+			{/* Header/Footer 없이 전체화면으로 표시되는 페이지 */}
+			<Route path="auth/kakao/callback" element={<KakaoRedirectPage />} />
+
+			{/* 비로그인 상태에서 접근 시 → /login 리다이렉트 */}
+			<Route element={<RouteGuard type="private" />}>
+				<Route path="performances/:id/seats" element={<SeatSelectPage />} />
+				<Route path="payments" element={<PaymentPage />} />
 			</Route>
-			<Route path="*" element={<NotFoundPage />} />
 		</Route>
 	)
 );

--- a/src/router/RouteGuard.tsx
+++ b/src/router/RouteGuard.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useIsLoggedIn } from "../store/authStore.ts";
+
+interface RouteGuardProps {
+	type: "private" | "public";
+}
+
+export default function RouteGuard({ type }: RouteGuardProps) {
+	const isLoggedIn = useIsLoggedIn();
+	const location = useLocation();
+
+	if (type === "private" && !isLoggedIn) {
+		return <Navigate to="/login" state={{ from: location.pathname }} replace />;
+	}
+
+	if (type === "public" && isLoggedIn) {
+		return <Navigate to="/" replace />;
+	}
+
+	return <Outlet />;
+}

--- a/src/types/ApiDataTypes.ts
+++ b/src/types/ApiDataTypes.ts
@@ -1,230 +1,54 @@
-/** 로그인하고 나서, 받는 로그인 응답 데이터 타입입니다. */
-export interface LoginResponse {
-	code: string;
-	data: {
-		accessToken: string;
-		refreshToken: string;
-		imageUrl: string;
-		name: string;
-		age: number;
-		email: string;
-	};
-}
+// 도메인별 타입 파일에서 re-export
+// 기존 import 호환성을 유지하면서 점진적으로 도메인별 import로 전환 가능
 
-/** 공연 목록을 조회 및 검색하기 위한 데이터 타입입니다. */
-export interface PerformanceListItem {
-	id: string;
-	name: string;
-	imageUrl: string;
-	type: string;
-	genre: string;
-	stadiumName: string;
-	startDate: string;
-	endDate: string;
-	adultOnly: boolean;
-}
+export { type LoginResponse } from "./auth.ts";
 
-export interface PerformancePagination {
-	page: number;
-	size: number;
-	totalItems: number;
-	totalPages: number;
-	hasNext: boolean;
-	hasPrevious: boolean;
-}
-/** 공연 목록을 조회하여 응답으로 받는 데이터 타입입니다. */
-export interface PerformanceData {
-	code: string;
-	data: {
-		performances: PerformanceListItem[];
-	};
-	pagination: PerformancePagination;
-}
+export {
+	type PerformanceListItem,
+	type PerformancePagination,
+	type PerformanceData,
+	type PopularPerformanceData,
+	type PerformanceDetailData,
+	type ReviewItem,
+	type ReviewPagination,
+	type ReviewData,
+	type CreateReviewData,
+} from "./performance.ts";
 
-/** 인기 공연 목록을 조회하기 위한 데이터 타입입니다. */
-export interface PopularPerformanceData {
-	code: string;
-	data: {
-		performances: PerformanceListItem[];
-	};
-}
+export {
+	type Stadium as stadium,
+	type ScheduleItem as scheduleList,
+	type SeatPrice as seatPrices,
+	type ReviewItem as reviewList,
+	type ReviewPagination as reviewPagination,
+	type ReviewData as reviewData,
+	type CreateReviewData as createReviewData,
+} from "./performance.ts";
 
-/** 공연 ID를 통해 공연의 상세 정보를 조회하는 데이터 타입입니다. */
-export type stadium = {
-	id: string;
-	name: string;
-	address: string;
-};
+export {
+	type SeatData,
+	type SelectSeatsData,
+	type SeatStateData,
+	type SeatWithState,
+	type ReservationPerformance,
+	type ReservationSeat,
+	type ReservationData,
+	type ReservationRequest,
+	type ReservationResponse,
+} from "./reservation.ts";
 
-export type scheduleList = {
-	id: string;
-	date: string;
-	time: string;
-};
+export {
+	type SeatData as seatData,
+	type SelectSeatsData as selectSeatsData,
+	type SeatStateData as seatStateData,
+	type ReservationPerformance as reservationPerformance,
+	type ReservationSeat as reservationSeats,
+	type ReservationData as reservationData,
+} from "./reservation.ts";
 
-export type seatPrices = {
-	section: string;
-	price: number;
-};
-
-export interface PerformanceDetailData {
-	code: string;
-	data: {
-		id: string;
-		imageUrl: string;
-		name: string;
-		type: string;
-		genre: string;
-		averageStar: number;
-		runningTime: number;
-		description: string;
-		adultOnly: boolean;
-		ticketOpenTime: string;
-		ticketCloseTime: string;
-		stadium: stadium;
-		performanceSchedules: scheduleList[];
-		seatSectionPrices: seatPrices[];
-	};
-}
-
-/** 공연 리뷰 목록을 조회할 때 사용하는 데이터 타입입니다. */
-export interface reviewList {
-	id: string;
-	writerName: string;
-	writerProfileImageUrl: string;
-	content: string;
-	star: number;
-	likeStatus: boolean;
-	likeCount: number;
-	createdAt: string;
-	updatedAt: string;
-}
-
-export interface reviewPagination {
-	page: number;
-	size: number;
-	totalItems: number;
-	totalPages: number;
-	hasNext: boolean;
-	hasPrevious: boolean;
-}
-
-export interface reviewData {
-	code: string;
-	data: {
-		reviews: reviewList[];
-		pagination: reviewPagination;
-	};
-}
-
-/**  공연 리뷰를 등록할 때 사용하는 데이터 타입입니다. */
-export interface createReviewData {
-	star: number;
-	content: string;
-}
-
-/** 예약 가능한 좌석을 선택할 때 사용하는 데이터 타입입니다. */
-export type seatData = {
-	id: string;
-	section: string;
-	row: number;
-	column: number;
-};
-
-export interface selectSeatsData {
-	code: string;
-	data: { seats: seatData[] };
-}
-
-/** 좌석 잠금 상태 여부를 판단할 때 사용하는 데이터 타입입니다. */
-export type seatStateData = {
-	id: string;
-	isLocked: boolean;
-};
-
-export type SeatWithState = seatData & { isLocked: boolean };
-
-/** 좌석을 예약한 공연의 정보들을 불러올 때 사용하는 데이터 타입입니다. */
-export type reservationPerformance = {
-	name: string;
-	scheduleDate: string;
-	scheduleTime: string;
-};
-
-export type reservationSeats = {
-	section: string;
-	row: number;
-	column: number;
-};
-
-export interface reservationData {
-	code: string;
-	data: {
-		reservationId: string;
-		performance: reservationPerformance;
-		seats: reservationSeats[];
-		totalAmount: number;
-	};
-}
-
-/** 선택한 좌석 요청을 보낼 때, 사용하는 데이터 타입입니다. */
-export interface ReservationRequest {
-	performanceId: string;
-	scheduleId: string;
-	seatIds: string[];
-	elapsedTime: number;
-	totalAmount: number;
-}
-
-/** 선택한 좌석 요청을 받을 때, 사용하는 데이터 타입입니다. */
-export interface ReservationResponse {
-	code: string;
-	data: {
-		reservationId: string;
-		performance: reservationPerformance;
-		seats: reservationSeats[];
-		totalAmount: number;
-	};
-}
-
-/** 예약한 좌석에 대한 결제 정보들을 불러올 때 사용하는 데이터 타입입니다.(결제 전) */
-export type paymentPerformance = {
-	name: string;
-	scheduleDate: string;
-	scheduleTime: string;
-};
-
-export type paymentSeats = {
-	section: string;
-	row: number;
-	column: number;
-};
-
-export interface BeforePaymentInfoData {
-	performance: paymentPerformance;
-	seats: paymentSeats[];
-	totalAmount: number;
-}
-
-/** 예약한 좌석에 대한 결제 정보들을 불러올 때 사용하는 데이터 타입입니다.(결제 후) */
-export interface AfterPaymentInfoData {
-	performance: paymentPerformance;
-	seats: paymentSeats[];
-}
-
-/** 결제 서버에 결제 승인 요청할 때 사용되는 데이터 타입입니다. */
-export interface ConfirmPaymentRequest {
-	orderId: string;
-	amount: number;
-	paymentKey: string;
-}
-
-/** 결제 서버에 결제 승인 응답을 받을 때 사용되는 데이터 타입입니다. */
-export interface ConfirmPaymentResponse {
-	code: string;
-	data: {
-		reservationId: string;
-		totalAmount: number;
-	};
-	message: string;
-}
+export {
+	type BeforePaymentInfoData,
+	type AfterPaymentInfoData,
+	type ConfirmPaymentRequest,
+	type ConfirmPaymentResponse,
+} from "./payment.ts";

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,12 @@
+/** 로그인하고 나서, 받는 로그인 응답 데이터 타입입니다. */
+export interface LoginResponse {
+	code: string;
+	data: {
+		accessToken: string;
+		refreshToken: string;
+		imageUrl: string;
+		name: string;
+		age: number;
+		email: string;
+	};
+}

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,0 +1,31 @@
+import type { ReservationPerformance, ReservationSeat } from "./reservation.ts";
+
+/** 예약한 좌석에 대한 결제 정보들을 불러올 때 사용하는 데이터 타입입니다.(결제 전) */
+export interface BeforePaymentInfoData {
+	performance: ReservationPerformance;
+	seats: ReservationSeat[];
+	totalAmount: number;
+}
+
+/** 예약한 좌석에 대한 결제 정보들을 불러올 때 사용하는 데이터 타입입니다.(결제 후) */
+export interface AfterPaymentInfoData {
+	performance: ReservationPerformance;
+	seats: ReservationSeat[];
+}
+
+/** 결제 서버에 결제 승인 요청할 때 사용되는 데이터 타입입니다. */
+export interface ConfirmPaymentRequest {
+	orderId: string;
+	amount: number;
+	paymentKey: string;
+}
+
+/** 결제 서버에 결제 승인 응답을 받을 때 사용되는 데이터 타입입니다. */
+export interface ConfirmPaymentResponse {
+	code: string;
+	data: {
+		reservationId: string;
+		totalAmount: number;
+	};
+	message: string;
+}

--- a/src/types/performance.ts
+++ b/src/types/performance.ts
@@ -1,0 +1,112 @@
+/** 공연 목록을 조회 및 검색하기 위한 데이터 타입입니다. */
+export interface PerformanceListItem {
+	id: string;
+	name: string;
+	imageUrl: string;
+	type: string;
+	genre: string;
+	stadiumName: string;
+	startDate: string;
+	endDate: string;
+	adultOnly: boolean;
+}
+
+export interface PerformancePagination {
+	page: number;
+	size: number;
+	totalItems: number;
+	totalPages: number;
+	hasNext: boolean;
+	hasPrevious: boolean;
+}
+
+/** 공연 목록을 조회하여 응답으로 받는 데이터 타입입니다. */
+export interface PerformanceData {
+	code: string;
+	data: {
+		performances: PerformanceListItem[];
+	};
+	pagination: PerformancePagination;
+}
+
+/** 인기 공연 목록을 조회하기 위한 데이터 타입입니다. */
+export interface PopularPerformanceData {
+	code: string;
+	data: {
+		performances: PerformanceListItem[];
+	};
+}
+
+/** 공연 ID를 통해 공연의 상세 정보를 조회하는 데이터 타입입니다. */
+export type Stadium = {
+	id: string;
+	name: string;
+	address: string;
+};
+
+export type ScheduleItem = {
+	id: string;
+	date: string;
+	time: string;
+};
+
+export type SeatPrice = {
+	section: string;
+	price: number;
+};
+
+export interface PerformanceDetailData {
+	code: string;
+	data: {
+		id: string;
+		imageUrl: string;
+		name: string;
+		type: string;
+		genre: string;
+		averageStar: number;
+		runningTime: number;
+		description: string;
+		adultOnly: boolean;
+		ticketOpenTime: string;
+		ticketCloseTime: string;
+		stadium: Stadium;
+		performanceSchedules: ScheduleItem[];
+		seatSectionPrices: SeatPrice[];
+	};
+}
+
+/** 공연 리뷰 목록을 조회할 때 사용하는 데이터 타입입니다. */
+export interface ReviewItem {
+	id: string;
+	writerName: string;
+	writerProfileImageUrl: string;
+	content: string;
+	star: number;
+	likeStatus: boolean;
+	likeCount: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface ReviewPagination {
+	page: number;
+	size: number;
+	totalItems: number;
+	totalPages: number;
+	hasNext: boolean;
+	hasPrevious: boolean;
+}
+
+export interface ReviewData {
+	code: string;
+	data: {
+		reviews: ReviewItem[];
+		pagination: ReviewPagination;
+	};
+}
+
+/** 공연 리뷰를 등록할 때 사용하는 데이터 타입입니다. */
+export interface CreateReviewData {
+	star: number;
+	content: string;
+}

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -1,0 +1,63 @@
+/** 예약 가능한 좌석을 선택할 때 사용하는 데이터 타입입니다. */
+export type SeatData = {
+	id: string;
+	section: string;
+	row: number;
+	column: number;
+};
+
+export interface SelectSeatsData {
+	code: string;
+	data: { seats: SeatData[] };
+}
+
+/** 좌석 잠금 상태 여부를 판단할 때 사용하는 데이터 타입입니다. */
+export type SeatStateData = {
+	id: string;
+	isLocked: boolean;
+};
+
+export type SeatWithState = SeatData & { isLocked: boolean };
+
+/** 좌석을 예약한 공연의 정보들을 불러올 때 사용하는 데이터 타입입니다. */
+export type ReservationPerformance = {
+	name: string;
+	scheduleDate: string;
+	scheduleTime: string;
+};
+
+export type ReservationSeat = {
+	section: string;
+	row: number;
+	column: number;
+};
+
+export interface ReservationData {
+	code: string;
+	data: {
+		reservationId: string;
+		performance: ReservationPerformance;
+		seats: ReservationSeat[];
+		totalAmount: number;
+	};
+}
+
+/** 선택한 좌석 요청을 보낼 때, 사용하는 데이터 타입입니다. */
+export interface ReservationRequest {
+	performanceId: string;
+	scheduleId: string;
+	seatIds: string[];
+	elapsedTime: number;
+	totalAmount: number;
+}
+
+/** 선택한 좌석 요청을 받을 때, 사용하는 데이터 타입입니다. */
+export interface ReservationResponse {
+	code: string;
+	data: {
+		reservationId: string;
+		performance: ReservationPerformance;
+		seats: ReservationSeat[];
+		totalAmount: number;
+	};
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 라우팅 구조와 API/타입 구조를 전반적으로 리팩토링하여, 인증 흐름 일관성, 레이아웃 중복 제거, TanStack Query 캐시 키 일관성, 도메인 기반 파일 구조 개선을 진행했습니다. 
- 이를 통해 페이지 단위에서 흩어져 있던 인증/레이아웃/쿼리 키 로직을 중앙에서 관리할 수 있도록 아키텍처를 재구성했습니다.


## 📝 변경 사항 요약 (Summary)

- GlobalLayout 도입으로 Header/Footer를 전역 레이아웃에서 관리하고, 개별 페이지의 중복 레이아웃 코드를 제거했습니다.

- RouteGuard 컴포넌트를 추가하여 ‎`type="private" | "public"` 기반으로 인증/비인증 접근 제어를 통합 관리하고, 각 페이지 내부의 ‎`localStorage` 토큰 체크 로직을 제거했습니다.

- ‎`queryKeys.ts`에 Query Key Factory 패턴을 도입하여 ‎`performanceKeys`, ‎`reviewKeys`, ‎`seatKeys`, ‎`paymentKeys`를 정의하고, TanStack Query 전역에서 동일한 쿼리 키를 사용하도록 통일했습니다.

- WaitingRoom과 SeatSelectPage에서 사용하던 좌석/좌석 상태 쿼리 키를 ‎`["seats", stadiumId]`, ‎`["seatStatus", scheduleId]`에서 ‎`seatKeys.definitions(stadiumId)`, ‎`seatKeys.states(scheduleId)`로 변경하여 캐시 키 불일치로 인한 버그를 해결했습니다.

- API 디렉토리를 도메인별(‎`auth/`, ‎`performance/`, ‎`payment/`, ‎`reservation/`)로 분리하고, 이에 따라 모든 import 경로를 새로운 구조에 맞게 수정했습니다.

- ‎`ApiDataTypes.ts`에 집중되어 있던 타입들을 ‎`auth.ts`, ‎`performance.ts`, ‎`reservation.ts`, ‎`payment.ts`로 분리하고, ‎`ApiDataTypes.ts`는 기존 이름을 유지하면서 re-export 허브로 동작하도록 변경해 하위 호환성을 유지했습니다.

- 로그인/마이페이지/메인/공연/결제 관련 페이지 컴포넌트에서 GlobalLayout/RouteGuard/Query Key Factory 도입에 맞춰 레이아웃 및 데이터 패칭 로직을 정리했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #121

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
