### PR TITLE
#122 refactor/feature(performance/header): 카테고리바 컴포넌트 분리 및 헤더 네비게이션 개선

### DIFF
--- a/src/api/performance/performance.ts
+++ b/src/api/performance/performance.ts
@@ -5,12 +5,18 @@ const apiUrl = process.env.BACKEND_SRT_API;
 
 const fetchPerformances = async (
 	page: number,
-	size = 32
+	size = 32,
+	genre?: string
 ): Promise<PerformanceData> => {
-	const url = `${apiUrl}/api/v1/performances?${new URLSearchParams({
+	const params: Record<string, string> = {
 		page: String(page),
 		size: String(size),
-	})}`;
+	};
+	if (genre) {
+		params.genre = genre;
+	}
+
+	const url = `${apiUrl}/api/v1/performances?${new URLSearchParams(params)}`;
 
 	return publicJSON(url, {
 		method: "GET",

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -3,7 +3,8 @@
 export const performanceKeys = {
 	all: ["performances"] as const,
 	lists: () => [...performanceKeys.all, "list"] as const,
-	list: (size: number) => [...performanceKeys.lists(), size] as const,
+	list: (size: number, genre?: string) =>
+		[...performanceKeys.lists(), size, genre ?? "all"] as const,
 	popular: () => [...performanceKeys.all, "popular"] as const,
 	details: () => [...performanceKeys.all, "detail"] as const,
 	detail: (id: string) => [...performanceKeys.details(), id] as const,

--- a/src/components/layout/Category.tsx
+++ b/src/components/layout/Category.tsx
@@ -3,20 +3,20 @@ import { Link, useLocation } from "react-router-dom";
 
 const categories = [
 	{ id: "all", label: "전체", path: "/performances" },
-	{ id: "CONCERT", label: "콘서트", path: "/performances?type=concert" },
-	{ id: "MUSICAL", label: "뮤지컬", path: "/performances?type=musical" },
+	{ id: "CONCERT", label: "콘서트", path: "/performances?genre=CONCERT" },
+	{ id: "MUSICAL", label: "뮤지컬", path: "/performances?genre=MUSICAL" },
 	{
 		id: "CHILDREN_THEATER",
 		label: "어린이극",
-		path: "/performances?type=children_theater",
+		path: "/performances?genre=CHILDREN_THEATER",
 	},
 	{
 		id: "DANCE",
 		label: "무용",
-		path: "/performances?type=dance",
+		path: "/performances?genre=DANCE",
 	},
-	{ id: "PLAY", label: "연극", path: "/performances?type=play" },
-	{ id: "OPERA", label: "오페라", path: "/performances?type=opera" },
+	{ id: "PLAY", label: "연극", path: "/performances?genre=PLAY" },
+	{ id: "OPERA", label: "오페라", path: "/performances?genre=OPERA" },
 ];
 
 export default function Category() {
@@ -25,8 +25,8 @@ export default function Category() {
 
 	useEffect(() => {
 		const params = new URLSearchParams(location.search);
-		const type = params.get("type");
-		setActiveCategory(type || "all");
+		const genre = params.get("genre");
+		setActiveCategory(genre || "all");
 	}, [location]);
 
 	return (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,8 +11,19 @@ import {
 	XMarkIcon,
 	MagnifyingGlassIcon,
 	ChevronRightIcon,
+	ChevronDownIcon,
 } from "@heroicons/react/24/solid";
 import useAuth from "../../hooks/useAuth.ts";
+
+const performanceCategories = [
+	{ label: "전체", path: "/performances" },
+	{ label: "콘서트", path: "/performances?genre=CONCERT" },
+	{ label: "뮤지컬", path: "/performances?genre=MUSICAL" },
+	{ label: "어린이극", path: "/performances?genre=CHILDREN_THEATER" },
+	{ label: "무용", path: "/performances?genre=DANCE" },
+	{ label: "연극", path: "/performances?genre=PLAY" },
+	{ label: "오페라", path: "/performances?genre=OPERA" },
+];
 
 export default function Header() {
 	// 모바일 크기에서 햄버거 메뉴 상태를 관리하는 state
@@ -26,11 +37,19 @@ export default function Header() {
 	const { user, logout } = useAuth();
 	// 드롭다운 외부 클릭 감지를 위한 ref를 생성
 	const dropdownRef = useRef<HTMLDivElement>(null);
+	// 카테고리 드롭다운 상태
+	const [isCategoryOpen, setIsCategoryOpen] = useState(false);
+	const categoryRef = useRef<HTMLDivElement>(null);
 
 	// 드롭다운 메뉴 링크 클릭 시 드롭다운를 닫는 헬퍼 함수
 	const handleNavigateWithDropdown = (path: string) => {
 		navigate(path);
 		setIsDropdownOpen(false);
+	};
+
+	const handleNavigateWithCategory = (path: string) => {
+		navigate(path);
+		setIsCategoryOpen(false);
 	};
 
 	// 모바일 크기에서 햄버거 메뉴 링크 클릭 시 메뉴가 자동으로 닫힘
@@ -122,11 +141,18 @@ export default function Header() {
 			) {
 				setIsDropdownOpen(false);
 			}
+			if (
+				categoryRef.current &&
+				!categoryRef.current.contains(event.target as Node)
+			) {
+				setIsCategoryOpen(false);
+			}
 		}
 
 		function handleEscapeKey(event: KeyboardEvent) {
 			if (event.key === "Escape") {
 				setIsDropdownOpen(false);
+				setIsCategoryOpen(false);
 			}
 		}
 
@@ -147,6 +173,16 @@ export default function Header() {
 					<div className="md:hidden absolute left-0">
 						<button type="button" onClick={() => setIsMenuOpen(true)}>
 							<Bars3Icon className="w-6 h-6" />
+						</button>
+					</div>
+
+					{/* 왼쪽: About 버튼 */}
+					<div className="absolute left-0 hidden md:flex items-center">
+						<button
+							type="button"
+							onClick={() => navigate("/about")}
+							className="px-5 py-2 transition-colors text-gray-500 rounded-full hover:bg-gray-200">
+							About
 						</button>
 					</div>
 
@@ -185,13 +221,39 @@ export default function Header() {
 						</div>
 
 						<nav className="hidden md:flex items-center justify-end flex-wrap gap-x-2 gap-y-2 md:gap-x-2">
-							{/* About 버튼 */}
-							<button
-								type="button"
-								onClick={() => navigate("/about")}
-								className="px-5 py-2 transition-colors text-gray-500 rounded-full hover:bg-gray-200">
-								About
-							</button>
+							{/* 공연 카테고리 드롭다운 */}
+							<div className="relative" ref={categoryRef}>
+								<button
+									type="button"
+									onClick={() => setIsCategoryOpen((prev) => !prev)}
+									className="flex items-center gap-1 px-5 py-2 transition-colors text-gray-500 rounded-full hover:bg-gray-200"
+									aria-expanded={isCategoryOpen}
+									aria-haspopup="true">
+									공연
+									<ChevronDownIcon
+										className={`w-4 h-4 transition-transform ${isCategoryOpen ? "rotate-180" : ""}`}
+									/>
+								</button>
+
+								{isCategoryOpen && (
+									<div
+										className="absolute right-0 mt-2 w-44 bg-white rounded-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.1)] border border-gray-100 overflow-hidden z-50 animate-fadeIn"
+										role="menu">
+										<div className="py-2">
+											{performanceCategories.map((cat) => (
+												<button
+													key={cat.label}
+													type="button"
+													onClick={() => handleNavigateWithCategory(cat.path)}
+													className="w-full px-4 py-2.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+													role="menuitem">
+													{cat.label}
+												</button>
+											))}
+										</div>
+									</div>
+								)}
+							</div>
 
 							{user ? (
 								// 로그인 상태
@@ -312,6 +374,17 @@ export default function Header() {
 								className="py-3 w-full text-left hover:bg-gray-100 rounded-md px-3">
 								공연
 							</button>
+							<div className="pl-6 flex flex-col gap-y-1">
+								{performanceCategories.slice(1).map((cat) => (
+									<button
+										key={cat.label}
+										type="button"
+										onClick={() => handleNavigate(cat.path)}
+										className="py-2 w-full text-left text-sm text-gray-500 hover:bg-gray-100 rounded-md px-3">
+										{cat.label}
+									</button>
+								))}
+							</div>
 							<button
 								type="button"
 								onClick={() => handleNavigate("/about")}

--- a/src/components/main/MainCategoryBar.tsx
+++ b/src/components/main/MainCategoryBar.tsx
@@ -1,0 +1,44 @@
+const categories = [
+	{ id: "all", label: "전체" },
+	{ id: "CONCERT", label: "콘서트" },
+	{ id: "MUSICAL", label: "뮤지컬" },
+	{ id: "CHILDREN_THEATER", label: "어린이극" },
+	{ id: "DANCE", label: "무용" },
+	{ id: "PLAY", label: "연극" },
+	{ id: "OPERA", label: "오페라" },
+];
+
+interface MainCategoryBarProps {
+	activeCategory: string;
+	onCategoryChange: (categoryId: string) => void;
+}
+
+export default function MainCategoryBar({
+	activeCategory,
+	onCategoryChange,
+}: MainCategoryBarProps) {
+	return (
+		<div className="bg-[#FBFBFB] border-b border-gray-200">
+			<div className="container mx-auto px-4">
+				<nav className="flex items-center gap-1 overflow-x-auto md:justify-center [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+					{categories.map(({ id, label }) => (
+						<button
+							key={id}
+							type="button"
+							onClick={() => onCategoryChange(id)}
+							className={`flex-shrink-0 px-6 py-4 text-sm md:text-base relative transition-colors whitespace-nowrap ${
+								activeCategory === id
+									? "text-gray-900 font-semibold"
+									: "text-gray-500 hover:text-gray-700"
+							}`}>
+							{label}
+							{activeCategory === id && (
+								<div className="absolute bottom-0 left-0 right-0 h-0.5 bg-gray-900 rounded-full" />
+							)}
+						</button>
+					))}
+				</nav>
+			</div>
+		</div>
+	);
+}

--- a/src/hooks/usePerformances.ts
+++ b/src/hooks/usePerformances.ts
@@ -4,10 +4,10 @@ import { PerformanceData } from "../types/ApiDataTypes.ts";
 import { ApiError } from "../lib/apiClient.ts";
 import { performanceKeys } from "../api/queryKeys.ts";
 
-export default function usePerformances(size = 32) {
+export default function usePerformances(size = 32, genre?: string) {
 	return useInfiniteQuery<PerformanceData, ApiError>({
-		queryKey: performanceKeys.list(size),
-		queryFn: ({ pageParam = 0 }) => fetchPerformances(pageParam, size),
+		queryKey: performanceKeys.list(size, genre),
+		queryFn: ({ pageParam = 0 }) => fetchPerformances(pageParam, size, genre),
 		getNextPageParam: (lastPage) => {
 			const { pagination } = lastPage;
 			return pagination?.hasNext ? pagination.page + 1 : undefined;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,47 +1,75 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
 import HeroCarousel from "../../components/carousel/HeroCarousel.tsx";
-import Category from "../../components/layout/Category.tsx";
-import { PerformanceListItem } from "../../types/ApiDataTypes.ts";
-import fetchPopularPerformances from "../../api/performance/popularPerformance.ts";
-import { performanceKeys } from "../../api/queryKeys.ts";
+import MainCategoryBar from "../../components/main/MainCategoryBar.tsx";
+import usePerformances from "../../hooks/usePerformances.ts";
+
+const categoryGenreMap: Record<string, string | undefined> = {
+	all: undefined,
+	CONCERT: "CONCERT",
+	MUSICAL: "MUSICAL",
+	CHILDREN_THEATER: "CHILDREN_THEATER",
+	DANCE: "DANCE",
+	PLAY: "PLAY",
+	OPERA: "OPERA",
+};
+
+const categoryLabelMap: Record<string, string> = {
+	all: "전체",
+	CONCERT: "콘서트",
+	MUSICAL: "뮤지컬",
+	CHILDREN_THEATER: "어린이극",
+	DANCE: "무용",
+	PLAY: "연극",
+	OPERA: "오페라",
+};
 
 export default function MainPage() {
 	const navigate = useNavigate();
+	const [activeCategory, setActiveCategory] = useState("all");
 
-	const { data, isLoading, isError, error } = useQuery({
-		queryKey: performanceKeys.popular(),
-		queryFn: () => fetchPopularPerformances(),
-		staleTime: 1000 * 60,
-	});
+	const genre = categoryGenreMap[activeCategory];
+	const { data, status } = usePerformances(10, genre);
 
 	const handleClick = (id: string, adultOnly: boolean) => {
 		sessionStorage.setItem("adultOnly", String(adultOnly));
 		navigate(`/performances/${id}`);
 	};
 
-	const performances: PerformanceListItem[] = data?.data.performances ?? [];
+	const performances =
+		data?.pages.flatMap((page) => page.data.performances) ?? [];
+
+	const sectionTitle =
+		activeCategory === "all"
+			? "인기 공연"
+			: `인기 ${categoryLabelMap[activeCategory]}`;
 
 	return (
 		<>
 			<HeroCarousel />
-			<Category />
+			<MainCategoryBar
+				activeCategory={activeCategory}
+				onCategoryChange={setActiveCategory}
+			/>
 			<div className="max-w-7xl mx-auto mb-6 px-4 md:px-6">
 				<h2 className="text-3xl text-blue-950 mt-12 mb-6 md:mt-16 md:mb-8">
-					인기 공연
+					{sectionTitle}
 				</h2>
 
-				{isLoading && (
+				{status === "loading" && (
 					<p className="text-center py-10">공연 목록을 불러오는 중입니다...</p>
 				)}
 
-				{isError && (
+				{status === "error" && (
 					<div className="text-center py-10">
 						<p className="text-red-500 font-semibold">오류가 발생했습니다.</p>
-						<p className="text-gray-600 mt-2">
-							{error instanceof Error ? error.message : "알 수 없는 에러"}
-						</p>
 					</div>
+				)}
+
+				{status === "success" && performances.length === 0 && (
+					<p className="text-center py-10 text-gray-500">
+						해당 카테고리의 인기 공연이 없습니다.
+					</p>
 				)}
 
 				{/* 공연 목록 */}

--- a/src/pages/performance/PerformancePage.tsx
+++ b/src/pages/performance/PerformancePage.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from "react-router-dom";
 import usePerformances from "../../hooks/usePerformances.ts";
 import InfiniteScroll from "../../components/ui/InfiniteScroll.tsx";
 import { AppErrorCode, statusMessage } from "../../lib/apiClient.ts";
@@ -5,6 +6,9 @@ import Category from "../../components/layout/Category.tsx";
 import PerformanceCard from "../../components/performance/list/PerformanceCard.tsx";
 
 export default function PerformancePage() {
+	const [searchParams] = useSearchParams();
+	const genre = searchParams.get("genre") || undefined;
+
 	const {
 		data,
 		fetchNextPage,
@@ -12,7 +16,7 @@ export default function PerformancePage() {
 		error,
 		isFetchingNextPage,
 		status,
-	} = usePerformances();
+	} = usePerformances(32, genre);
 
 	if (status === "loading") return <p>로딩 중</p>;
 	if (status === "error") {


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 공연 카테고리 탐색 경험을 개선하기 위해 카테고리바 컴포넌트 분리, 헤더 내 공연 카테고리 진입점 추가, 공연 목록 필터링 파라미터 정리 작업을 진행했습니다.

- 메인 페이지와 공연 목록 페이지의 역할을 분리하고, URL 쿼리 파라미터와 API 요청 파라미터를 ‎`genre` 기준으로 일관되게 맞추는 것을 목표로 했습니다.

## 📝 변경 사항 요약 (Summary)

- 카테고리바 컴포넌트 분리
  - 메인 페이지 전용 `MainCategoryBar` 컴포넌트 신규 생성
  - 메인 페이지 -> 카테고리 탭 선택 시 해당 장르의 공연 목록 API 호출
  - 공연 목록 페이지 -> 기존 `Category` 컴포넌트 유지
- 헤더바 공연 카테고리 진입점 추가
  - 데스크탑 -> 로그인 왼쪽에 공연 카테고리 드롭다운 버튼 추가
  - 모바일 -> 사이드바 공연 메뉴 하위에 카테고리 서브메뉴 추가
  - About 버튼을 헤더 왼쪽으로 이동
- 공연 필터링 파라미터 수정
  - API 응답 구조에 맞춰 `type` → `genre` 파라미터로 전환
  - `fetchPerformances`, `usePerformances`, `queryKeys`에 `genre` 파라미터 추가
  - `Category`, `Header`, `PerformancePage`의 URL 쿼리 파라미터 `genre`으로 통일

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #122 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
